### PR TITLE
Improvements to the reference/evaluate-reference skills

### DIFF
--- a/.github/skills/evaluate-reference/SKILL.md
+++ b/.github/skills/evaluate-reference/SKILL.md
@@ -93,6 +93,19 @@ Flag it if it depends on app-specific naming, opaque identifiers, cached data fr
 7. For each library that was not implemented, decide whether it is out of scope, not yet implemented here, or a missed supporting library.
 8. Prefer these outcomes in order: `fix implementation` -> `add missing supporting library` -> `leave unchanged; honest capture gap`.
 
+## Implementation Defects To Flag
+
+Beyond attribute coverage, flag these implementation-shape defects:
+
+- **Span not wrapping the SDK call.** The span must be open around the library invocation, with request attributes set inline before the call and response attributes set from the returned object inside the same `with` / `using` block. A scenario that captures the response, closes (or never opened) the span, and then replays attributes onto a separately-opened or post-hoc span is a defect, even if the final attribute set looks correct.
+- **Private API as scenario entry point.** The scenario must invoke the library's public API. Patching private methods to open spans around them is acceptable, but the scenario calling private methods directly is a defect — it does not credibly demonstrate what native instrumentation could capture.
+
+## Not Defects
+
+Do not flag these as problems:
+
+- **Library-native sibling spans.** Extra spans produced by the library's natural execution shape — worker tasks that run after planning, retries, converters, fall-through paths — are honest reference data, not noise. If invoking the public entry point produces extra LLM round-trips beyond the one being demonstrated, accept them.
+
 ## Determining the PR Changeset
 
 Use `gh pr diff <number>` (not `git diff main`) to get the changeset. A stale local `main` causes `git diff main` to include unrelated commits.

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -42,6 +42,8 @@ If the value would have to be guessed, carried forward from an unrelated call, o
 
 When editing reference tests in this repository:
 
+- Open the span **around** the SDK call, not after it. Set request attributes inline before invoking the library, invoke the library inside the `with` block, then set response attributes from the returned object inside the same `with` block. Do not capture a completion and replay attribute emission against it after the span has closed or against a separately-opened span.
+- When the library's public entry point does not expose the operation directly (for example, an internal-only span boundary inside a library helper), it is acceptable to patch the library's private methods to open spans around them. The scenario itself must still invoke the **public** API. Do not call private methods directly from the scenario.
 - Emit attributes inline at the span or activity site.
 - Keep request, derived, and response attributes close together.
 - Reuse the same current-call variable that the SDK call uses when emitting request attributes.
@@ -67,6 +69,8 @@ When editing reference tests in this repository:
 The default expectation is repository-wide reference coverage for all supporting libraries, not a single illustrative example.
 
 When the same semantic-convention change applies to multiple ecosystems, look for parallel implementations instead of stopping after the first passing library.
+
+Prefer the library's natural execution shape over surgical paths that minimize trace output. Sibling spans from worker tasks, retries, converters, fall-through paths, and similar library-native behavior are honest reference data, not noise to suppress. If invoking the public entry point produces extra LLM round-trips or extra spans beyond the one being demonstrated, accept them.
 
 ## Output Format
 


### PR DESCRIPTION
Captures three rules learned while reviewing #97 into the reference and evaluate-reference skills.