### PR TITLE
Pin @github/copilot CLI install via npm lockfile

### DIFF
--- a/.github/scripts/copilot-cli/package-lock.json
+++ b/.github/scripts/copilot-cli/package-lock.json
@@ -1,0 +1,128 @@
+{
+  "name": "copilot-cli-install",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copilot-cli-install",
+      "version": "0.0.0",
+      "dependencies": {
+        "@github/copilot": "1.0.40"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40.tgz",
+      "integrity": "sha512-s35c/9R5q8O2ZQi/rzU9TBpum/DU06dczDSfmepCTisRHVTTKWS703J7kZhZYqL6OIGqnhmLfx4A7afT8YVKKA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.40",
+        "@github/copilot-darwin-x64": "1.0.40",
+        "@github/copilot-linux-arm64": "1.0.40",
+        "@github/copilot-linux-x64": "1.0.40",
+        "@github/copilot-win32-arm64": "1.0.40",
+        "@github/copilot-win32-x64": "1.0.40"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40.tgz",
+      "integrity": "sha512-syHKff/G53VzosHRXG6pX+MEc00tMdly0SZS4jC0fFUSY2/6R7lgi4IEZt57Q6WKdjBiqn8EvEQ94efdRdPEzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40.tgz",
+      "integrity": "sha512-ai6PgHLx5SgC7Ht3Hy2tNepdnAnqcWaPPtYFaP2UGS69r1O87JBA/pB2QHVZP3vX34/4RyoOB/WQ1kiT5pvcpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40.tgz",
+      "integrity": "sha512-mAh8GmGmkkUiFFzBIvXYmReSIw5c3NWHme0iYT2v/72RWNAwRq4HLKP9NhHapZqUPyi7jQnRxllYPybZDFS6Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40.tgz",
+      "integrity": "sha512-gCo6RgpXwa39FZSdj5dMkN/z0xT/NS29MpkeYQ/S34SSoUsSbIKUWcuoMjRiXpaDWWuXQsFjXcqnwNs67JOejA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40.tgz",
+      "integrity": "sha512-59ANg2xfeeWwl8UNqVe4sk2OAizgMjKVRgTALYExHMc8p5HJyL8nrQ9np6pIkO/De0UpR8rUzk4D8oCqU7XLIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40.tgz",
+      "integrity": "sha512-dKS5L7SwzXZI/gaY9LIn8eoTGEPgczGLIgt1KwjfkHgk3achHwIuEjxSqPRVD1Z7q08uuOcuwVzOlwE8V38zNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    }
+  }
+}

--- a/.github/scripts/copilot-cli/package.json
+++ b/.github/scripts/copilot-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "copilot-cli-install",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned install of @github/copilot CLI used by .github/workflows/pr-review-dashboard.yml",
+  "dependencies": {
+    "@github/copilot": "1.0.40"
+  }
+}

--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -29,7 +29,10 @@ jobs:
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot@1.0.40
+        run: |
+          npm ci --prefix .github/scripts/copilot-cli
+          # expose the locally-installed `copilot` binary to subsequent steps
+          echo "$GITHUB_WORKSPACE/.github/scripts/copilot-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Generate dashboard
         env:


### PR DESCRIPTION
Fixes the Scorecard [Pinned-Dependencies alert #7](https://github.com/open-telemetry/semantic-conventions-genai/security/code-scanning/7) (`npmCommand not pinned by hash`) on the PR dashboard workflow.
