### PR TITLE
Schedule .github/scripts/copilot-cli updates with GitHub Actions group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,8 +44,8 @@
     {
       "groupName": "GitHub Actions",
       "commitMessageTopic": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
+      "matchFileNames": [
+        ".github/**"
       ],
       "schedule": [
         "* * 2 * *"


### PR DESCRIPTION
Brings the `@github/copilot` (and any other `.github/**` deps) onto the same monthly schedule as GitHub Actions updates so they don't open PRs at arbitrary times.