### PR TITLE
Exclude mock server from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "CodeQL config"
+
+# The mock server under reference/src/semconv_genai/mock_server is local test
+# infrastructure used by the reference scenarios. Exclude it from analysis.
+paths-ignore:
+  - reference/src/semconv_genai/mock_server/**

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,8 +44,8 @@
     {
       "groupName": "GitHub Actions",
       "commitMessageTopic": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
+      "matchFileNames": [
+        ".github/**"
       ],
       "schedule": [
         "* * 2 * *"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
         uses: github/codeql-action/init@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1


### PR DESCRIPTION
The mock server under `reference/src/semconv_genai/mock_server` is local test infrastructure used by the reference scenarios. Exclude it from CodeQL analysis.