### PR TITLE
Update dependency google-genai to v2 (google-genai scenario only)

### DIFF
--- a/reference/scenarios/google-genai/pyproject.toml
+++ b/reference/scenarios/google-genai/pyproject.toml
@@ -3,7 +3,7 @@ name = "google-genai-reference-test"
 version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [
-    "google-genai==1.75.0",
+    "google-genai==2.0.0",
     "genai-reference-shared",
 ]
 

--- a/reference/scenarios/google-genai/uv.lock
+++ b/reference/scenarios/google-genai/uv.lock
@@ -267,7 +267,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.75.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -281,9 +281,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/17/577bec0473020fccbd66fae74005018e23cb068e012b2047e93139efac69/google_genai-2.0.0.tar.gz", hash = "sha256:6589916a1175e4c1119c6aa5051c53b1657e3650fea81cadb4d745bf35c1eb2f", size = 538318, upload-time = "2026-05-07T20:12:23.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1a/55e8a0d11dacbf9b24466f74e4af0845023fc7b7bfd44a26912b793d35d3/google_genai-2.0.0-py3-none-any.whl", hash = "sha256:3c834c0894cfa0324c0281fbb302db5626fdeb2c74ed31990384fbc0112fcaa4", size = 791903, upload-time = "2026-05-07T20:12:21.508Z" },
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genai-reference-shared", editable = "../../shared" },
-    { name = "google-genai", specifier = "==1.75.0" },
+    { name = "google-genai", specifier = "==2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `google-genai` from `1.75.0` to `2.0.0` in the `google-genai` reference scenario only.

Splits out the working portion of #112. The `google-adk` scenario is intentionally left on `google-genai==1.75.0` because `google-adk==1.32.0` declares `google-genai<2,>=1.72`, which is what was causing Renovate's `renovate/artifacts` lockfile step to fail in #112.

Per the upstream [v2.0.0 release notes](https://github.com/googleapis/python-genai/blob/HEAD/CHANGELOG.md#200-2026-05-07), the breaking changes are limited to the Interactions API; `GenerateContent` usage (what this scenario exercises) is unaffected.