### PR TITLE
Rename 'reference instrumentation' to 'reference scenarios' in docs and tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Update the reference scenarios under `reference/scenarios/` to demonstrate this.
 ## Checklist
 
 - [ ] Motivation section filled in above
-- [ ] Reference instrumentation and scenarios updated for affected libraries
+- [ ] Reference scenarios updated for affected libraries
 - [ ] Changelog entry added under `Unreleased` in `CHANGELOG.md` for any change to the conventions that a consumer would care about. Editorial changes (typos, pure rewording, repo tooling) don't need an entry.
 
 See [CONTRIBUTING.md]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,8 @@ through several coupled surfaces:
   hand-edited.
 - `schema-snapshot/registry.yaml` — committed snapshot, refreshed by
   `make generate-all`.
-- `reference/scenarios/<library>/` — runnable Python reference instrumentation
-  (`scenario.py`) that proves proposed conventions are capturable.
+- `reference/scenarios/<library>/` — runnable Python reference scenarios
+  (`scenario.py`) that prove proposed conventions are capturable.
 
 ## PR scope
 

--- a/.github/instructions/reference-scenarios.instructions.md
+++ b/.github/instructions/reference-scenarios.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: "Conventions for reference instrumentation under reference/scenarios. Covers inline attribute emission, span boundaries, public-entry-point usage, and what to ignore."
+description: "Conventions for reference scenarios under reference/scenarios. Covers inline attribute emission, span boundaries, public-entry-point usage, and what to ignore."
 applyTo: "reference/scenarios/**/scenario.py"
 ---
 

--- a/.github/skills/evaluate-reference/SKILL.md
+++ b/.github/skills/evaluate-reference/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: evaluate-reference
-description: 'Use when reviewing completed reference instrumentation, reference scenario outputs, or data results against a semantic-conventions PR, upstream proposal, or spec change. Evaluates reference coverage, capturability, direct observability, derivable fields, missing supporting libraries, and honest capture gaps without forcing fake compliance.'
+description: 'Use when reviewing completed reference scenarios, scenario outputs, or data results against a semantic-conventions PR, upstream proposal, or spec change. Evaluates reference coverage, capturability, direct observability, derivable fields, missing supporting libraries, and honest capture gaps without forcing fake compliance.'
 argument-hint: 'Describe the semantic-conventions PR and the reference implementation, files, or results to evaluate.'
 ---
 
 # Reference Evaluation
 
-Use this skill after reference instrumentation has been added for a semantic-conventions PR and the repository needs an evaluation of coverage quality and capturability.
+Use this skill after reference scenarios have been added for a semantic-conventions PR and the repository needs an evaluation of coverage quality and capturability.
 
 ## Goal
 

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reference
-description: 'Use when implementing a semantic-conventions PR, upstream proposal diff, spec change, or new GenAI span or attribute in this repository. Adds reference instrumentation, reference scenario updates, inline attribute emission, and data coverage for every Python library that credibly supports the change.'
+description: 'Use when implementing a semantic-conventions PR, upstream proposal diff, spec change, or new GenAI span or attribute in this repository. Adds reference scenarios, inline attribute emission, and data coverage for every Python library that credibly supports the change.'
 argument-hint: 'Describe the semantic-conventions PR or the convention changes that need reference coverage.'
 ---
 


### PR DESCRIPTION
The canonical artifact in this repo is `reference/scenarios/<library>/scenario.py`. The directory, CONTRIBUTING.md, the instructions file, the runner CLI, and most prose already use "reference scenario(s)". A few stragglers still said "reference instrumentation", which is misleading: in the OTel ecosystem "instrumentation" usually means a published auto-instrumentation library (lifecycle hooks, config knobs, production hardening). Our `scenario.py` files are deliberately *not* that — they're hand-rolled, single-file proofs of capturability.
