### PR TITLE
gen-ai: add document modality to multimodal content parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 💡 Enhancements 💡
 
+- Add `document` value to the `Modality` enum in the GenAI input/output/system-instructions
+  message JSON schemas. Enables capturing PDF/DOCX (and similar) parts that today have to fall
+  through to the free-form `string` branch of the modality `anyOf`.
 - Mark `gen_ai.agent.name` as sampling-relevant on `create_agent`, `invoke_agent` client, and `invoke_agent` internal spans.
   ([#107](https://github.com/open-telemetry/semantic-conventions-genai/pull/107))
 - Add `plan` operation for GenAI agent planning/task decomposition spans.

--- a/docs/gen-ai/gen-ai-input-messages.json
+++ b/docs/gen-ai/gen-ai-input-messages.json
@@ -225,7 +225,8 @@
             "enum": [
                 "image",
                 "video",
-                "audio"
+                "audio",
+                "document"
             ],
             "title": "Modality",
             "type": "string"

--- a/docs/gen-ai/gen-ai-output-messages.json
+++ b/docs/gen-ai/gen-ai-output-messages.json
@@ -162,7 +162,8 @@
             "enum": [
                 "image",
                 "video",
-                "audio"
+                "audio",
+                "document"
             ],
             "title": "Modality",
             "type": "string"

--- a/docs/gen-ai/gen-ai-system-instructions.json
+++ b/docs/gen-ai/gen-ai-system-instructions.json
@@ -118,7 +118,8 @@
             "enum": [
                 "image",
                 "video",
-                "audio"
+                "audio",
+                "document"
             ],
             "title": "Modality",
             "type": "string"

--- a/docs/gen-ai/non-normative/examples-llm-calls.md
+++ b/docs/gen-ai/non-normative/examples-llm-calls.md
@@ -268,6 +268,13 @@ See the [normative JSON schema](/docs/gen-ai/gen-ai-input-messages.json) for mor
         "modality": "audio",
         "mime_type": "audio/wav",
         "content": "aGVsbG8gd29ybGQgaW1hZ2luZSB0aGlzIGlzIGFuIGltYWdlCg=="
+      },
+      // A document (e.g. a PDF for KYC extraction) referenced by URI
+      {
+        "type": "uri",
+        "modality": "document",
+        "mime_type": "application/pdf",
+        "uri": "s3://my-bucket/kyc-form.pdf"
       }
     ]
   }

--- a/docs/gen-ai/non-normative/models.ipynb
+++ b/docs/gen-ai/non-normative/models.ipynb
@@ -136,6 +136,7 @@
     "    IMAGE = \"image\"\n",
     "    VIDEO = \"video\"\n",
     "    AUDIO = \"audio\"\n",
+    "    DOCUMENT = \"document\"\n",
     "\n",
     "\n",
     "class ReasoningPart(BaseModel):\n",

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -117,9 +117,9 @@ def run_chat_with_document_input():
 
     Exercises the `document` value of the `Modality` enum on a `BlobPart`
     in `gen_ai.input.messages`. Anthropic's Messages API has a first-class
-    `document` content block that exposes the mime type, source bytes, and
-    filename directly on the SDK call boundary -- so every emitted BlobPart
-    field traces back to the SDK arg without any Files-API roundtrip:
+    `document` content block that exposes the mime type and source bytes
+    directly on the SDK call boundary -- so every emitted BlobPart field
+    traces back to the SDK arg without any Files-API roundtrip:
 
       {"type": "document",
        "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -112,12 +112,107 @@ def run_chat():
         print(f"    -> {resp.content[0].text[:60]}")
 
 
+def run_chat_with_document_input():
+    """Scenario: chat with a base64 document block (document modality).
+
+    Exercises the `document` value of the `Modality` enum on a `BlobPart`
+    in `gen_ai.input.messages`. Anthropic's Messages API has a first-class
+    `document` content block that exposes the mime type, source bytes, and
+    filename directly on the SDK call boundary -- so every emitted BlobPart
+    field traces back to the SDK arg without any Files-API roundtrip:
+
+      {"type": "document",
+       "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
+    """
+    import anthropic
+    import base64
+
+    print("  [chat_document] chat with PDF document block (reference implementation)")
+    request_model = "claude-sonnet-4-20250514"
+    request_max_tokens = 100
+    instruction = "Summarize the attached document in one sentence."
+    pdf_bytes = b"%PDF-1.4\n%mock pdf for reference scenario\n%%EOF\n"
+    pdf_b64 = base64.b64encode(pdf_bytes).decode("ascii")
+    mime_type = "application/pdf"
+
+    # SDK boundary: native Anthropic document content block.
+    user_content = [
+        {"type": "text", "text": instruction},
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": mime_type, "data": pdf_b64},
+        },
+    ]
+    messages = [{"role": "user", "content": user_content}]
+    client = anthropic.Anthropic(base_url=MOCK_BASE_URL, api_key="mock-key")
+
+    # Canonical OTel parts: TextPart + BlobPart(modality="document"). Each
+    # BlobPart field is derivable from the document block above:
+    #   - mime_type: `source.media_type`
+    #   - content:   `source.data` (already base64)
+    #   - modality:  classification of media_type "application/pdf"
+    input_parts = [
+        {"type": "text", "content": instruction},
+        {
+            "type": "blob",
+            "modality": "document",
+            "mime_type": mime_type,
+            "content": pdf_b64,
+        },
+    ]
+    input_messages = json.dumps([{"role": "user", "parts": input_parts}])
+
+    host, port = mock_server_host_port(MOCK_BASE_URL)
+    span_attributes_doc = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "anthropic",
+        "gen_ai.request.model": request_model,
+    }
+    if host:
+        span_attributes_doc["server.address"] = host
+    if port is not None:
+        span_attributes_doc["server.port"] = port
+    with _reference_tracer.start_as_current_span(
+        "chat claude-sonnet-4-20250514", attributes=span_attributes_doc
+    ) as span:
+        span.set_attribute("gen_ai.request.max_tokens", request_max_tokens)
+        span.set_attribute("gen_ai.input.messages", input_messages)
+        resp = client.messages.create(
+            model=request_model,
+            max_tokens=request_max_tokens,
+            messages=messages,
+        )
+        span.set_attribute("gen_ai.response.model", resp.model)
+        span.set_attribute("gen_ai.response.id", resp.id)
+        span.set_attribute("gen_ai.response.finish_reasons", [resp.stop_reason])
+        if resp.usage:
+            cache_creation = getattr(resp.usage, "cache_creation_input_tokens", None) or 0
+            cache_read = getattr(resp.usage, "cache_read_input_tokens", None) or 0
+            total_input = resp.usage.input_tokens + cache_creation + cache_read
+            span.set_attribute("gen_ai.usage.input_tokens", total_input)
+            span.set_attribute("gen_ai.usage.output_tokens", resp.usage.output_tokens)
+        output_messages = json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "content": block.text}],
+                    "finish_reason": resp.stop_reason,
+                }
+                for block in resp.content
+                if hasattr(block, "text")
+            ]
+        )
+        span.set_attribute("gen_ai.output.messages", output_messages)
+        print(f"    -> {resp.content[0].text[:60]}")
+
+
 def main():
     print("=== Reference Implementation: Anthropic Reference Implementation ===")
 
     tp, lp, mp = setup_otel()
 
     run_chat()
+    run_chat_with_document_input()
 
     flush_and_shutdown(tp, lp, mp)
 

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -124,8 +124,9 @@ def run_chat_with_document_input():
       {"type": "document",
        "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
     """
-    import anthropic
     import base64
+
+    import anthropic
 
     print("  [chat_document] chat with PDF document block (reference implementation)")
     request_model = "claude-sonnet-4-20250514"

--- a/reference/scenarios/aws-bedrock/scenario.py
+++ b/reference/scenarios/aws-bedrock/scenario.py
@@ -190,6 +190,103 @@ def run_converse_tool_call_reference(client):
             print(f"    -> {content[0]['text'][:60]}")
 
 
+def run_converse_with_document_input_reference(client):
+    """Scenario: Bedrock Converse API with a DocumentBlock (document modality).
+
+    The Converse API exposes a first-class DocumentBlock that carries the
+    payload format, name, and raw bytes directly on the SDK call boundary
+    -- so every emitted BlobPart field on `gen_ai.input.messages` traces
+    back to the SDK arg without any out-of-band lookup:
+
+      {"document": {"format": "pdf", "name": "...",
+                    "source": {"bytes": <raw bytes>}}}
+    """
+    import base64
+
+    print("  [converse_document] Bedrock Converse with PDF document block (reference implementation)")
+    request_model = "anthropic.claude-3-haiku-20240307-v1:0"
+    instruction = "Summarize the attached document in one sentence."
+    pdf_bytes = b"%PDF-1.4\n%mock pdf for reference scenario\n%%EOF\n"
+    pdf_format = "pdf"
+    document_name = "sample-kyc"
+
+    # SDK boundary: native Bedrock Converse DocumentBlock.
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": instruction},
+                {
+                    "document": {
+                        "format": pdf_format,
+                        "name": document_name,
+                        "source": {"bytes": pdf_bytes},
+                    }
+                },
+            ],
+        }
+    ]
+
+    # Canonical OTel parts: TextPart + BlobPart(modality="document"). Each
+    # BlobPart field is derivable from the DocumentBlock above:
+    #   - mime_type: classification of `format` "pdf" -> "application/pdf"
+    #   - content:   base64-encoded `source.bytes`
+    #   - modality:  classification of mime "application/pdf" -> "document"
+    pdf_b64 = base64.b64encode(pdf_bytes).decode("ascii")
+    mime_type = "application/pdf"
+    input_parts = [
+        {"type": "text", "content": instruction},
+        {
+            "type": "blob",
+            "modality": "document",
+            "mime_type": mime_type,
+            "content": pdf_b64,
+        },
+    ]
+    input_messages = json.dumps([{"role": "user", "parts": input_parts}])
+
+    host, port = mock_server_host_port(MOCK_BASE_URL)
+    span_attributes_doc = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "aws.bedrock",
+        "gen_ai.request.model": request_model,
+    }
+    if host:
+        span_attributes_doc["server.address"] = host
+    if port is not None:
+        span_attributes_doc["server.port"] = port
+    with _reference_tracer.start_as_current_span(
+        "chat anthropic.claude-3-haiku-20240307-v1:0", attributes=span_attributes_doc
+    ) as span:
+        span.set_attribute("gen_ai.input.messages", input_messages)
+        response = client.converse(
+            modelId=request_model,
+            messages=messages,
+        )
+        stop_reason = response.get("stopReason")
+        if stop_reason:
+            span.set_attribute("gen_ai.response.finish_reasons", [stop_reason])
+        usage = response.get("usage", {})
+        if usage.get("inputTokens") is not None:
+            span.set_attribute("gen_ai.usage.input_tokens", usage["inputTokens"])
+        if usage.get("outputTokens") is not None:
+            span.set_attribute("gen_ai.usage.output_tokens", usage["outputTokens"])
+        text = response["output"]["message"]["content"][0]["text"]
+        span.set_attribute(
+            "gen_ai.output.messages",
+            json.dumps(
+                [
+                    {
+                        "role": "assistant",
+                        "parts": [{"type": "text", "content": text}],
+                        **({"finish_reason": stop_reason} if stop_reason else {}),
+                    }
+                ]
+            ),
+        )
+        print(f"    -> {text[:60]}")
+
+
 def run_embeddings_reference(client):
     """Scenario: Bedrock Titan Embeddings with reference implementation."""
     import json as _json
@@ -230,6 +327,7 @@ def main():
 
     run_converse_reference(client)
     run_converse_tool_call_reference(client)
+    run_converse_with_document_input_reference(client)
     run_embeddings_reference(client)
 
     flush_and_shutdown(tp, lp, mp)

--- a/reference/scenarios/openai/scenario.py
+++ b/reference/scenarios/openai/scenario.py
@@ -312,9 +312,7 @@ def run_chat_with_document_input_reference(client):
         span_attributes_doc["server.address"] = host
     if port is not None:
         span_attributes_doc["server.port"] = port
-    with _reference_tracer.start_as_current_span(
-        "chat gpt-4o-mini", attributes=span_attributes_doc
-    ) as span:
+    with _reference_tracer.start_as_current_span("chat gpt-4o-mini", attributes=span_attributes_doc) as span:
         span.set_attribute("gen_ai.input.messages", input_messages)
         resp = client.chat.completions.create(
             model=request_model,

--- a/reference/scenarios/openai/scenario.py
+++ b/reference/scenarios/openai/scenario.py
@@ -265,39 +265,51 @@ def run_chat_tool_call_reference(client):
 
 
 def run_chat_with_document_input_reference(client):
-    """Scenario: chat with a document attachment (document modality).
+    """Scenario: chat with an inline PDF document attachment (document modality).
 
-    Exercises the `document` value of the `Modality` enum on a `UriPart`
-    in `gen_ai.input.messages`. The user message carries a text instruction
-    plus a PDF reference, mirroring how a document-extraction workload
-    (e.g. KYC) surfaces in the canonical message JSON.
+    Exercises the `document` value of the `Modality` enum on a `BlobPart`
+    in `gen_ai.input.messages`. Every emitted field on the BlobPart is
+    derivable directly from the OpenAI SDK call boundary:
+
+    - The SDK call passes a `{"type": "file", "file": {"file_data": "data:application/pdf;base64,..."}}`
+      content block. The `file_data` value is a data-URI a native
+      instrumentation can parse without a separate Files-API roundtrip.
+    - `mime_type` comes from the data-URI prefix (`application/pdf`).
+    - `content` is the base64 payload of the data-URI.
+    - `modality: "document"` is the classification of `application/pdf`
+      under the new enum value -- the whole point of this PR.
     """
-    print("  [chat_document] chat with PDF document input (reference implementation)")
-    request_model = "gpt-4o-mini"
-    document_uri = "https://example.com/sample-kyc.pdf"
-    document_mime_type = "application/pdf"
-    instruction = "Summarize the attached document in one sentence."
+    import base64
 
-    # OpenAI Chat Completions accepts a multimodal `content` array for
-    # vision/document-capable models. For a PDF the documented shape is a
-    # `file` content block referencing an uploaded file by id.
+    print("  [chat_document] chat with inline PDF document input (reference implementation)")
+    request_model = "gpt-4o-mini"
+    instruction = "Summarize the attached document in one sentence."
+    # Minimal valid-looking PDF bytes; the mock LLM does not parse this.
+    pdf_bytes = b"%PDF-1.4\n%mock pdf for reference scenario\n%%EOF\n"
+    pdf_b64 = base64.b64encode(pdf_bytes).decode("ascii")
+    mime_type = "application/pdf"
+    data_uri = f"data:{mime_type};base64,{pdf_b64}"
+    filename = "sample-kyc.pdf"
+
+    # SDK boundary: documented `file` content block with inline `file_data`.
     user_content = [
         {"type": "text", "text": instruction},
-        {"type": "file", "file": {"file_id": "file-mock-kyc"}},
+        {"type": "file", "file": {"file_data": data_uri, "filename": filename}},
     ]
     messages = [{"role": "user", "content": user_content}]
 
-    # Canonical OTel parts representation: a TextPart followed by a UriPart
-    # with modality="document". The URI points at the same artifact the
-    # `file` content block references (in production this is typically an
-    # S3 / MinIO / GCS object URI captured by an offload-on-capture step).
+    # Canonical OTel parts: TextPart + BlobPart(modality="document"). Each
+    # field on the BlobPart traces back to the SDK arg above:
+    #   - mime_type: parsed from the data-URI prefix
+    #   - content:   the base64 portion of the data-URI
+    #   - modality:  derived classification of mime_type "application/pdf"
     input_parts = [
         {"type": "text", "content": instruction},
         {
-            "type": "uri",
+            "type": "blob",
             "modality": "document",
-            "mime_type": document_mime_type,
-            "uri": document_uri,
+            "mime_type": mime_type,
+            "content": pdf_b64,
         },
     ]
     input_messages = json.dumps([{"role": "user", "parts": input_parts}])

--- a/reference/scenarios/openai/scenario.py
+++ b/reference/scenarios/openai/scenario.py
@@ -264,6 +264,80 @@ def run_chat_tool_call_reference(client):
             print(f"    -> {choice.message.content[:60]}")
 
 
+def run_chat_with_document_input_reference(client):
+    """Scenario: chat with a document attachment (document modality).
+
+    Exercises the `document` value of the `Modality` enum on a `UriPart`
+    in `gen_ai.input.messages`. The user message carries a text instruction
+    plus a PDF reference, mirroring how a document-extraction workload
+    (e.g. KYC) surfaces in the canonical message JSON.
+    """
+    print("  [chat_document] chat with PDF document input (reference implementation)")
+    request_model = "gpt-4o-mini"
+    document_uri = "https://example.com/sample-kyc.pdf"
+    document_mime_type = "application/pdf"
+    instruction = "Summarize the attached document in one sentence."
+
+    # OpenAI Chat Completions accepts a multimodal `content` array for
+    # vision/document-capable models. For a PDF the documented shape is a
+    # `file` content block referencing an uploaded file by id.
+    user_content = [
+        {"type": "text", "text": instruction},
+        {"type": "file", "file": {"file_id": "file-mock-kyc"}},
+    ]
+    messages = [{"role": "user", "content": user_content}]
+
+    # Canonical OTel parts representation: a TextPart followed by a UriPart
+    # with modality="document". The URI points at the same artifact the
+    # `file` content block references (in production this is typically an
+    # S3 / MinIO / GCS object URI captured by an offload-on-capture step).
+    input_parts = [
+        {"type": "text", "content": instruction},
+        {
+            "type": "uri",
+            "modality": "document",
+            "mime_type": document_mime_type,
+            "uri": document_uri,
+        },
+    ]
+    input_messages = json.dumps([{"role": "user", "parts": input_parts}])
+
+    host, port = mock_server_host_port(MOCK_BASE_URL)
+    span_attributes_doc = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": request_model,
+    }
+    if host:
+        span_attributes_doc["server.address"] = host
+    if port is not None:
+        span_attributes_doc["server.port"] = port
+    with _reference_tracer.start_as_current_span(
+        "chat gpt-4o-mini", attributes=span_attributes_doc
+    ) as span:
+        span.set_attribute("gen_ai.input.messages", input_messages)
+        resp = client.chat.completions.create(
+            model=request_model,
+            messages=messages,
+        )
+        span.set_attribute("gen_ai.response.model", resp.model)
+        span.set_attribute("gen_ai.response.id", resp.id)
+        span.set_attribute("gen_ai.response.finish_reasons", [c.finish_reason for c in resp.choices])
+        output_messages = [
+            {
+                "role": c.message.role,
+                "parts": [{"type": "text", "content": c.message.content}],
+                "finish_reason": c.finish_reason,
+            }
+            for c in resp.choices
+        ]
+        span.set_attribute("gen_ai.output.messages", json.dumps(output_messages))
+        if resp.usage:
+            span.set_attribute("gen_ai.usage.input_tokens", resp.usage.prompt_tokens)
+            span.set_attribute("gen_ai.usage.output_tokens", resp.usage.completion_tokens)
+        print(f"    -> {resp.choices[0].message.content[:60]}")
+
+
 def run_embeddings_reference(client):
     """Scenario: embedding generation with reference implementation."""
     print("  [embeddings] embedding generation (reference implementation)")
@@ -308,6 +382,7 @@ def main():
     run_chat_reference(client)
     run_chat_streaming_reference(client)
     run_chat_tool_call_reference(client)
+    run_chat_with_document_input_reference(client)
     run_embeddings_reference(client)
 
     flush_and_shutdown(tp, lp, mp)


### PR DESCRIPTION
## Description

Adds `document` as a value of the `Modality` enum on `BlobPart`, `FilePart`, and `UriPart` in the gen-ai input, output, and system-instructions message JSON schemas. PDFs, DOCX, and other office-document payloads currently fall through to the free-form `string` branch of the `modality` `anyOf`; this change gives them a first-class enum value alongside `image` / `video` / `audio`.

Concrete shape on the wire:

```jsonc
{
  "type": "blob",
  "modality": "document",
  "mime_type": "application/pdf",
  "content": "<base64 of raw PDF bytes>"
}
```

The Pydantic source model in `docs/gen-ai/non-normative/models.ipynb` is the source of truth; the three JSON schemas are regenerated from it.

Follow-up from the closed `open-telemetry/semantic-conventions#3673`. Closes (or significantly advances) #50. Sister PRs in this repo: [`byte_size` #143](https://github.com/open-telemetry/semantic-conventions-genai/pull/143) and [`stripped_reason` #144](https://github.com/open-telemetry/semantic-conventions-genai/pull/144). The three are independent and additive.

## Motivation

**User journey:** content auditability and cost-attribution for document-processing GenAI workloads.

A high-volume real workload that drove this: **BFSI KYC (Know Your Customer) extraction** — a customer uploads a passport or utility bill as a PDF, the GenAI app extracts identity fields, and the instrumentation needs to record what kind of content was sent. Today the only way to convey "this was a PDF document, not an image" is either (a) leak the mime type alone and ask consumers to classify, or (b) fall through to the free-form `string` branch of `modality`, fragmenting how producers describe documents.

Both options block:

- **Cost attribution by content type** — operators want per-tenant per-modality token-usage rollups; `document` is a distinct class with different per-token cost characteristics (PDFs are commonly OCR'd or embedded by the model, which has cost implications different from raw images).
- **Compliance dashboards** that need to answer "how many document-class payloads were captured this quarter?" — a stable, normative enum value makes this a single-attribute query rather than a mime-type classification expression in every consumer.

**Prior art:**
- Anthropic's `messages` API has a first-class `document` content-block type today.
- OpenAI Chat Completions consumes PDFs via a `file` content block with inline `file_data` (data URI) or `file_id`.
- AWS Bedrock Converse has a native `DocumentBlock` (`format` + `source.bytes` + `name`).
- The reference implementation in [`genai-otel-instrument`](https://github.com/Mandark-droid/genai_otel_instrument) (v1.1.1) already emits `modality: "document"` on PDFs captured by its OpenAI / Anthropic / Bedrock instrumentors, validated end-to-end through MinIO + OTel collector + OpenSearch on KYC extraction workloads.

Issue [#50](https://github.com/open-telemetry/semantic-conventions-genai/issues/50) enumerates three follow-ups that this PR partially addresses (the modality enum) and that the broader split (`byte_size` in #143, optional `filename` as a future PR) will round out.

## Prototype

Three matching reference scenarios were added (per @trask's evaluation on the first iteration: the emitted fields must derive from the SDK call boundary, no fabricated URIs or out-of-band lookups):

| Scenario | SDK boundary | BlobPart derivation |
|---|---|---|
| `reference/scenarios/openai/run_chat_with_document_input_reference` | `{"type":"file", "file": {"file_data": "data:application/pdf;base64,...", "filename": "..."}}` | mime_type from data-URI prefix; content from base64 portion; modality from mime classification |
| `reference/scenarios/anthropic/run_chat_with_document_input` | `{"type":"document", "source": {"type":"base64", "media_type":"application/pdf", "data":"..."}}` | mime_type ← `source.media_type`; content ← `source.data`; modality from mime classification |
| `reference/scenarios/aws-bedrock/run_converse_with_document_input_reference` | `{"document": {"format":"pdf", "name":"...", "source": {"bytes": <raw>}}}` | mime_type from `format` (`pdf` → `application/pdf`); content = base64 of `source.bytes`; modality from mime classification |

All three are runnable end-to-end against the local mock LLM server (`uv run run-scenario <library>`); weaver live-check reports `✔ No after_resolution policy violation` on each. Every emitted BlobPart field on `gen_ai.input.messages` is derivable from a value present on a single synchronous `client.X.create(...)` call — no Files-API roundtrip required, no application-side URI fabrication.

A worked example was also added to `docs/gen-ai/non-normative/examples-llm-calls.md` under the existing Multimodal-inputs block.

`make check-policies` and `make generate-all` both run clean against this branch on a local Docker host (Weaver v0.23.0); `generate-all` produces zero working-tree drift.

## Checklist

- [x] Motivation section filled in above
- [x] Reference scenarios updated for affected libraries
- [x] Changelog entry added under `Unreleased` in `CHANGELOG.md`
