### PR TITLE
gen-ai: add optional byte_size to multimodal content parts

### DIFF
--- a/changelog.d/143.enhancement.md
+++ b/changelog.d/143.enhancement.md
@@ -1,0 +1,1 @@
+Add optional `byte_size` (non-negative integer) to `BlobPart`, `FilePart`, and `UriPart` in the GenAI input and output message JSON schemas. Lets instrumentations record the size of a captured media payload for cost-of-capture telemetry and storage planning; omitted when the size is not cheaply observable (e.g. a pre-existing remote URI).

--- a/docs/gen-ai/non-normative/examples-llm-calls.md
+++ b/docs/gen-ai/non-normative/examples-llm-calls.md
@@ -239,7 +239,11 @@ See the [normative JSON schema](/model/gen-ai/gen-ai-input-messages.json) for mo
         "mime_type": "image/png",
         "uri": "https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/refs/heads/main/static/img/logos/opentelemetry-horizontal-color.png"
       },
-      // A video with a vendor specific URI
+      // A video with a vendor specific URI. `byte_size` is omitted here because
+      // the size of a pre-existing remote URI is generally not observable to the
+      // instrumentation without downloading the content. Set `byte_size` on a
+      // `uri` part only when the instrumentation observed the bytes before they
+      // became a URI (e.g. an inline payload uploaded to an object store).
       {
         "type": "uri",
         "modality": "video",
@@ -257,11 +261,13 @@ See the [normative JSON schema](/model/gen-ai/gen-ai-input-messages.json) for mo
         "modality": "image",
         "file_id": "provider_fileid_123"
       },
-      // An inline image
+      // An inline image. `byte_size` is unambiguous here because the
+      // instrumentation observed the payload directly.
       {
         "type": "blob",
         "modality": "image",
         "mime_type": "image/png",
+        "byte_size": 37,
         "content": "aGVsbG8gd29ybGQgaW1hZ2luZSB0aGlzIGlzIGFuIGltYWdlCg=="
       },
       // Inline audio

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -204,6 +204,15 @@ class BlobPart(BaseModel):
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
     )
+    byte_size: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Size of the captured payload in bytes — the raw decoded byte length, not the length "
+            "of the base64-encoded `content` string on the wire. Useful for cost-of-capture "
+            "telemetry and storage planning."
+        ),
+    )
     content: bytes = Field(
         description="Raw bytes of the attached data. This field SHOULD be encoded as a base64 string when serialized to JSON."
     )
@@ -220,6 +229,14 @@ class FilePart(BaseModel):
     )
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
+    )
+    byte_size: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Size of the referenced file in bytes, as observed by the instrumentation at capture "
+            "time. Useful for cost-of-capture telemetry and storage planning."
+        ),
     )
     file_id: str = Field(
         description="An identifier referencing a file that was pre-uploaded to the provider."
@@ -239,6 +256,14 @@ class UriPart(BaseModel):
     )
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
+    )
+    byte_size: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Size of the URI-referenced payload in bytes, as observed by the instrumentation at "
+            "capture time. Useful for cost-of-capture telemetry and storage planning."
+        ),
     )
     uri: str = Field(
         description=(

--- a/model/gen-ai/gen-ai-input-messages.json
+++ b/model/gen-ai/gen-ai-input-messages.json
@@ -34,6 +34,20 @@
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
                 },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the captured payload in bytes \u2014 the raw decoded byte length, not the length of the base64-encoded `content` string on the wire. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
+                },
                 "content": {
                     "description": "Raw bytes of the attached data. This field SHOULD be encoded as a base64 string when serialized to JSON.",
                     "format": "binary",
@@ -204,6 +218,20 @@
                     ],
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
+                },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the referenced file in bytes, as observed by the instrumentation at capture time. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
                 },
                 "file_id": {
                     "description": "An identifier referencing a file that was pre-uploaded to the provider.",
@@ -519,6 +547,20 @@
                     ],
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
+                },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the URI-referenced payload in bytes, as observed by the instrumentation at capture time. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
                 },
                 "uri": {
                     "description": "A URI referencing attached data. It should not be a base64 data URL, which should use the `blob` part instead. The URI may use a scheme known to the provider api (e.g. `gs://bucket/object.png`), or be a publicly accessible location.",

--- a/model/gen-ai/gen-ai-output-messages.json
+++ b/model/gen-ai/gen-ai-output-messages.json
@@ -34,6 +34,20 @@
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
                 },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the captured payload in bytes \u2014 the raw decoded byte length, not the length of the base64-encoded `content` string on the wire. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
+                },
                 "content": {
                     "description": "Raw bytes of the attached data. This field SHOULD be encoded as a base64 string when serialized to JSON.",
                     "format": "binary",
@@ -126,6 +140,20 @@
                     ],
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
+                },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the referenced file in bytes, as observed by the instrumentation at capture time. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
                 },
                 "file_id": {
                     "description": "An identifier referencing a file that was pre-uploaded to the provider.",
@@ -550,6 +578,20 @@
                     ],
                     "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
                     "title": "Modality"
+                },
+                "byte_size": {
+                    "anyOf": [
+                        {
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Size of the URI-referenced payload in bytes, as observed by the instrumentation at capture time. Useful for cost-of-capture telemetry and storage planning.",
+                    "title": "Byte Size"
                 },
                 "uri": {
                     "description": "A URI referencing attached data. It should not be a base64 data URL, which should use the `blob` part instead. The URI may use a scheme known to the provider api (e.g. `gs://bucket/object.png`), or be a publicly accessible location.",


### PR DESCRIPTION
## Description

Adds an optional `byte_size` field on `BlobPart`, `FilePart`, and `UriPart` in the gen-ai input, output, and system-instructions message JSON schemas. `byte_size` captures the size, in bytes, of the captured or referenced media payload as observed by the instrumentation at the time of capture.

Concretely each part type carries its own focused description:

| Part | `byte_size` description |
|---|---|
| `BlobPart` | Size of the captured payload in bytes — the raw decoded byte length, not the length of the base64-encoded `content` string on the wire. |
| `FilePart` | Size of the referenced file in bytes, as observed by the instrumentation at capture time. |
| `UriPart` | Size of the URI-referenced payload in bytes, as observed by the instrumentation at capture time. |

The Pydantic source models in `docs/gen-ai/non-normative/models.ipynb` declare `byte_size: Optional[int] = Field(default=None, ge=0, ...)` so the regenerated JSON schemas carry `"minimum": 0` inside the `anyOf` integer branch — negative values are rejected by validators rather than silently accepted.

Follow-up from the closed PR open-telemetry/semantic-conventions#3673 (split into three small PRs per the new repo's "keep PRs small" guidance: this one, the [`document` modality PR #142](https://github.com/open-telemetry/semantic-conventions-genai/pull/142), and the [`stripped_reason` PR #144](https://github.com/open-telemetry/semantic-conventions-genai/pull/144)). The three are independent and additive.

## Motivation

**User journey:** cost-of-capture telemetry, storage planning, and capacity forecasting for content-capturing instrumentation.

A single logical multimodal request may be carried inline (`BlobPart` with base64 `content`), by URI (`UriPart` pointing at S3 / GCS / MinIO / similar), or by provider-side file id (`FilePart`). Without a uniform `byte_size`, an operator who wants to answer "how much media data are we ingesting per minute / per tenant / per modality?" has to:

- For `BlobPart`: base64-decode `content` and count bytes (and decide whether to do that per-span, which is expensive).
- For `UriPart`: dereference the URI to a backing store and HEAD it (involves an extra request and trust in the store).
- For `FilePart`: ask the provider's files API for size metadata (extra API call, rate-limited, provider-specific).

Putting an optional `byte_size` directly on the captured part lets the producing instrumentation record what it already knows (it just saw the bytes or just got back a `content-length` header / file metadata) so consumers don't have to re-derive it later.

**Prior art:**
- AWS X-Ray / Bedrock spans record request and response sizes as flat attributes.
- OpenAI's Files API exposes `bytes` on every file object — instrumentation that's about to upload via `Files.create()` already has this number.
- The reference implementation in [`genai-otel-instrument`](https://github.com/Mandark-droid/genai_otel_instrument) (v1.1.1) already populates an equivalent inside its dual-emission JSON when `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai` — this PR upstreams the convention.

## Prototype

This PR ships the schema change in `docs/gen-ai/`. The repo's reference scenarios under `reference/scenarios/<library>/` are all currently text-only — none emit `BlobPart`/`FilePart`/`UriPart` today — so there is no obvious existing scenario to add `byte_size` to without first introducing a multimodal scenario.

I flagged this as an open question in the original PR body (and on the closed-and-refiled open-telemetry/semantic-conventions#3673): would maintainers prefer (a) extending an existing `<library>` scenario (e.g. `openai`) with a multimodal call that emits `byte_size`, or (b) a dedicated `openai-multimodal` (or similar) scenario, given the SDK call shape changes? Happy to do either as a follow-up — leaving this checkbox unchecked rather than guessing the shape. Cross-referenced from open-telemetry/semantic-conventions-genai#142, where the document-modality counterpart of this question was raised and approved without a scenario.

End-to-end producer verification: the [`genai-otel-instrument`](https://github.com/Mandark-droid/genai_otel_instrument) library emits `byte_size` on URI parts captured by its OpenAI / Anthropic / Bedrock instrumentors, validated through an OTel collector → OpenSearch pipeline against a MinIO-backed media store; the actual size value observed at capture time round-trips into the `gen_ai.input.messages` span attribute as the JSON schema in this PR describes.

## Checklist

- [x] Motivation section filled in above
- [ ] Reference scenarios updated for affected libraries — *deferred pending maintainer guidance on shape; see Prototype section*
- [x] Changelog entry added under `Unreleased` in `CHANGELOG.md`
