### PR TITLE
Only run PR dashboard workflow on upstream repo

### DIFF
--- a/.github/workflows/pr-review-dashboard.yml
+++ b/.github/workflows/pr-review-dashboard.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update-dashboard:
+    if: github.repository == 'open-telemetry/semantic-conventions-genai'
     permissions:
       issues: write
     environment: protected


### PR DESCRIPTION
Since it runs often and fails on forks.