### PR TITLE
Use workflow token for dashboard state pushes

### DIFF
--- a/.github/scripts/pull-request-dashboard/state_branch.py
+++ b/.github/scripts/pull-request-dashboard/state_branch.py
@@ -92,7 +92,7 @@ def reset_state(state_dir: Path, state_branch: str) -> bool:
 
 def push_state(state_dir: Path, state_branch: str) -> bool:
     cmd = ["git"]
-    token = os.environ.get("OTELBOT_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN")
     if token:
         credential = base64.b64encode(f"x-access-token:{token}".encode()).decode()
         cmd.extend(["-c", f"http.https://github.com/.extraheader=AUTHORIZATION: basic {credential}"])

--- a/.github/workflows/pull-request-dashboard.yml
+++ b/.github/workflows/pull-request-dashboard.yml
@@ -104,7 +104,7 @@ jobs:
     permissions:
       actions: read
       checks: read
-      contents: read
+      contents: write
       issues: read
       pull-requests: read
     environment: protected
@@ -154,7 +154,7 @@ jobs:
       - name: Generate and update dashboard
         env:
           TRIGGER_PR_NUMBER: ${{ needs.resolve-trigger.outputs.pr_number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # needed for reading approver team membership (org:read)
           OTELBOT_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -178,7 +178,7 @@ jobs:
       group: ${{ github.workflow }}-notify-${{ github.repository }}
       cancel-in-progress: false
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
     environment: protected
     runs-on: ubuntu-latest
@@ -196,7 +196,7 @@ jobs:
 
       - name: Send Slack notifications
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OTELBOT_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_MAP_JSON: ${{ secrets.SLACK_USER_MAP_JSON }}


### PR DESCRIPTION
Use GITHUB_TOKEN for pull request dashboard state-branch pushes while keeping the otelbot app token for approver team membership reads. Grant contents: write only to the jobs that update the git-backed dashboard state.