### PR TITLE
Refresh PR dashboard on check suite updates

### DIFF
--- a/.github/scripts/pull-request-dashboard/WEBHOOK_SETUP.md
+++ b/.github/scripts/pull-request-dashboard/WEBHOOK_SETUP.md
@@ -32,10 +32,12 @@ Set repository permissions:
 
 - Pull requests: read-only (needed to subscribe to the events below)
 - Issues: read-only (needed to subscribe to the events below)
+- Checks: read-only (needed to subscribe to CI check events)
 - Actions: read and write
 
 Subscribe to events:
 
+- Check suite
 - Pull request
 - Issue comment
 - Pull request review

--- a/.github/scripts/pull-request-dashboard/netlify/functions/github-webhook.js
+++ b/.github/scripts/pull-request-dashboard/netlify/functions/github-webhook.js
@@ -4,6 +4,7 @@ const GITHUB_API_VERSION = "2022-11-28";
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
 
 const ALLOWED_ACTIONS = {
+  check_suite: new Set(["completed", "requested", "rerequested"]),
   pull_request: new Set([
     "assigned",
     "closed",
@@ -152,6 +153,13 @@ function extractPullRequestNumber(eventName, payload) {
     return payload.issue.number;
   }
 
+  const checkPullRequestNumber = extractPullRequestNumberFromPullRequests([
+    payload.check_suite && payload.check_suite.pull_requests,
+  ]);
+  if (checkPullRequestNumber) {
+    return checkPullRequestNumber;
+  }
+
   if (payload.pull_request && Number.isInteger(payload.pull_request.number)) {
     return payload.pull_request.number;
   }
@@ -161,6 +169,20 @@ function extractPullRequestNumber(eventName, payload) {
     payload.review_thread && payload.review_thread.pull_request_url,
     payload.thread && payload.thread.pull_request_url,
   ]);
+}
+
+function extractPullRequestNumberFromPullRequests(pullRequestLists) {
+  for (const pullRequests of pullRequestLists) {
+    if (!Array.isArray(pullRequests)) {
+      continue;
+    }
+    for (const pullRequest of pullRequests) {
+      if (pullRequest && Number.isInteger(pullRequest.number)) {
+        return pullRequest.number;
+      }
+    }
+  }
+  return undefined;
 }
 
 function extractPullRequestNumberFromUrls(urls) {

--- a/.github/workflows/pull-request-dashboard.yml
+++ b/.github/workflows/pull-request-dashboard.yml
@@ -74,7 +74,7 @@ jobs:
               || { echo "bad PR number: $pr_number"; exit 1; }
           fi
           if [[ -n "$trigger_event" ]]; then
-            [[ "$trigger_event" =~ ^(schedule|workflow_dispatch|pull_request|issue_comment|pull_request_review|pull_request_review_comment|pull_request_review_thread)$ ]] \
+            [[ "$trigger_event" =~ ^(schedule|workflow_dispatch|check_suite|pull_request|issue_comment|pull_request_review|pull_request_review_comment|pull_request_review_thread)$ ]] \
               || { skip_event "bad trigger event: $trigger_event"; }
           fi
           if [[ -n "$trigger_action" ]]; then


### PR DESCRIPTION
Refresh the pull request dashboard when GitHub emits check suite webhook events so stale CI pending/failing state is corrected before the next scheduled rebuild.