### PR TITLE
Fix broken schema URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on the core semantic conventions.
 
 ## Schema URL
 
-<https://opentelemetry.io/schemas/gen-ai/1.42.0>
+<https://opentelemetry.io/schemas/gen-ai-dev/1.42.0-dev>
 
 ## Read the docs
 


### PR DESCRIPTION
## Summar

The Schema URL link in the top-level README was broken:

- It pointed to `https://opentelemetry.io/schemas/gen-ai/1.42.0`, which returns HTTP 404.
- It also did not match the repo's canonical schema URL — `model/manifest.yaml` and `RELEASING.md` both use the dev channel form `https://opentelemetry.io/schemas/gen-ai-dev/1.42.0-dev`.
