### PR TITLE
gen-ai: add evaluation operation name and gen_ai.evaluate.internal span

### DIFF
--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -453,7 +453,7 @@ attributes:
           note: >
             Used when the operation being instrumented is an evaluation step,
             such as running an LLM-as-judge, a scoring metric, or a benchmark suite.
-            The span SHOULD carry one or more gen_ai.evaluation.result events.
+            The span SHOULD carry one or more `gen_ai.evaluation.result` events.
           stability: development
     brief: The name of the operation being performed.
     note: >

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -447,6 +447,14 @@ attributes:
           value: "delete_memory_store"
           brief: 'Delete or deprovision a memory store'
           stability: development
+        - id: evaluation
+          value: "evaluation"
+          brief: 'Evaluation of GenAI output quality, accuracy, or other characteristics'
+          note: >
+            Used when the operation being instrumented is an evaluation step,
+            such as running an LLM-as-judge, a scoring metric, or a benchmark suite.
+            The span SHOULD carry one or more gen_ai.evaluation.result events.
+          stability: development
     brief: The name of the operation being performed.
     note: >
       If one of the predefined values applies, but specific system uses a different name it's RECOMMENDED to document it in the semantic

--- a/model/gen-ai/spans.yaml
+++ b/model/gen-ai/spans.yaml
@@ -572,6 +572,58 @@ spans:
         requirement_level:
           conditionally_required: when available
 
+  - type: gen_ai.evaluate.internal
+    kind: internal
+    name:
+      note: >
+        **Span name** SHOULD be `evaluate {gen_ai.evaluation.name}` when a
+        single named metric is being evaluated, or `evaluate` when multiple
+        metrics are evaluated within the same span.
+    brief: >
+      Represents an evaluation of GenAI output quality, accuracy, or other
+      characteristics. Carries one or more `gen_ai.evaluation.result` events.
+    note: |
+      The `gen_ai.operation.name` SHOULD be `evaluation`.
+
+      **Span name** SHOULD be `evaluate {gen_ai.evaluation.name}` when a
+      single named metric is being evaluated, or `evaluate` when multiple
+      metrics are evaluated within the same span.
+
+      This span SHOULD be the parent of `gen_ai.evaluation.result` events.
+      When evaluation is performed post-hoc (separate process from inference),
+      `gen_ai.response.id` on the event correlates the evaluation back to the
+      original inference span.
+
+      Instrumentations SHOULD report this span when they can reliably
+      determine that the operation being instrumented is an evaluation step,
+      and SHOULD NOT report it for generic inference spans that happen to
+      include self-evaluation logic.
+
+      Examples: DeepEval GEval, Azure AI Evaluation, DSPy Evaluate,
+      RAGAS, custom LLM-as-judge pipelines.
+    stability: development
+    attributes:
+      - ref_group: attributes.gen_ai.error
+      - ref: gen_ai.operation.name
+        requirement_level: required
+        sampling_relevant: true
+      - ref: gen_ai.evaluation.name
+        requirement_level:
+          conditionally_required: when a single named metric is being evaluated
+        sampling_relevant: true
+      - ref: gen_ai.provider.name
+        requirement_level:
+          conditionally_required: when the evaluation uses a GenAI judge model
+      - ref: gen_ai.request.model
+        requirement_level:
+          conditionally_required: when the evaluation uses a GenAI judge model
+      - ref: gen_ai.conversation.id
+        requirement_level:
+          conditionally_required: when available and the evaluation is scoped to a specific conversation
+      - ref: gen_ai.agent.name
+        requirement_level:
+          conditionally_required: when the evaluation is scoped to a specific agent
+
 span_refinements:
   - id: openai.inference.client
     ref: gen_ai.inference.client

--- a/model/gen-ai/spans.yaml
+++ b/model/gen-ai/spans.yaml
@@ -572,12 +572,12 @@ spans:
         requirement_level:
           conditionally_required: when available
 
-  - type: gen_ai.evaluate.internal
+  - type: gen_ai.evaluation.internal
     kind: internal
     name:
       note: >
-        **Span name** SHOULD be `evaluate {gen_ai.evaluation.name}` when a
-        single named metric is being evaluated, or `evaluate` when multiple
+        **Span name** SHOULD be `evaluation {gen_ai.evaluation.name}` when a
+        single named metric is being evaluated, or `evaluation` when multiple
         metrics are evaluated within the same span.
     brief: >
       Represents an evaluation of GenAI output quality, accuracy, or other
@@ -585,8 +585,8 @@ spans:
     note: |
       The `gen_ai.operation.name` SHOULD be `evaluation`.
 
-      **Span name** SHOULD be `evaluate {gen_ai.evaluation.name}` when a
-      single named metric is being evaluated, or `evaluate` when multiple
+      **Span name** SHOULD be `evaluation {gen_ai.evaluation.name}` when a
+      single named metric is being evaluated, or `evaluation` when multiple
       metrics are evaluated within the same span.
 
       This span SHOULD be the parent of `gen_ai.evaluation.result` events.


### PR DESCRIPTION
Closes / relates to: https://github.com/open-telemetry/semantic-conventions/issues/3398

### Problem

The `gen_ai.evaluation.result` event was merged in #2563 and is already used by multiple reference scenarios (deepeval, azure-ai-evaluation, dspy). However there is currently no standard **span type** to carry it, and no well-known `gen_ai.operation.name` value for evaluation operations.

This causes two concrete problems:

1. **Invisible in dashboards** — evaluation spans cannot be queried or filtered at the operation level alongside `invoke_agent`, `execute_tool`, and `chat` spans.
2. **Ecosystem fragmentation** — OpenSearch's [genai-observability-sdk-py](https://github.com/opensearch-project/opensearch-genai-observability-py) already uses `gen_ai.operation.name: "evaluation"` as a custom value. Without a standard, every instrumentation library invents its own string.

### Changes

**`model/gen-ai/registry.yaml`** — add `evaluation` enum member to `gen_ai.operation.name`:

```yaml
- id: evaluation
  value: "evaluation"
  brief: 'Evaluation of GenAI output quality, accuracy, or other characteristics'
  note: >
    Used when the operation being instrumented is an evaluation step,
    such as running an LLM-as-judge, a scoring metric, or a benchmark suite.
    The span SHOULD carry one or more gen_ai.evaluation.result events.
  stability: development
```

**`model/gen-ai/spans.yaml`** — add `gen_ai.evaluate.internal` span:

- `gen_ai.operation.name` = `evaluation` (required)
- `gen_ai.evaluation.name` (conditionally required: single named metric)
- `gen_ai.provider.name` (conditionally required: when using a judge model)
- `gen_ai.request.model` (conditionally required: when using a judge model)
- `gen_ai.conversation.id` (conditionally required: conversation-scoped eval)
- `gen_ai.agent.name` (conditionally required: agent-scoped eval)

Span name SHOULD be `evaluate {gen_ai.evaluation.name}` for a single metric, or `evaluate` when multiple metrics share one span.

### Design notes

- This is a purely additive change; no existing attributes or spans are modified.
- The span is `INTERNAL` kind, consistent with `gen_ai.execute_tool.internal` and `gen_ai.plan.internal`.
- A follow-up PR will add a reference scenario demonstrating the span in a benchmark context (deepeval / azure-ai-evaluation).

### Verification

```bash
# Weaver resolves the updated registry without new errors
cd reference/
uv run run-scenario deepeval   # exit 0, no new violations
```