### PR TITLE
gen-ai: sync reference data.json files with scenario implementations

### DIFF
--- a/reference/reports/inference-span.md
+++ b/reference/reports/inference-span.md
@@ -18,7 +18,7 @@
 | gen_ai.request.choice.count | [crewai], [google-adk], [llamaindex], [openai] |
 | gen_ai.request.model | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai], [vertexai] |
 | gen_ai.request.seed | [autogen], [crewai], [openai], [pydantic-ai] |
-| gen_ai.request.stream | (none) |
+| gen_ai.request.stream | [openai] |
 | gen_ai.request.top_k | [google-adk] |
 | server.port | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [cohere], [crewai], [google-adk], [langchain], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
 
@@ -33,13 +33,13 @@
 | gen_ai.request.temperature | [autogen], [crewai], [google-adk], [llamaindex], [openai], [pydantic-ai] |
 | gen_ai.request.top_p | [autogen], [crewai], [google-adk], [openai], [pydantic-ai] |
 | gen_ai.response.finish_reasons | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [claude-agent-sdk], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [pydantic-ai], [vertexai] |
-| gen_ai.response.id | [anthropic], [autogen], [azure-ai-inference], [azure-openai], [cohere], [crewai], [dspy], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
-| gen_ai.response.model | [anthropic], [autogen], [azure-ai-inference], [azure-openai], [crewai], [dspy], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
+| gen_ai.response.id | [anthropic], [autogen], [azure-ai-inference], [azure-openai], [claude-agent-sdk], [cohere], [crewai], [dspy], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
+| gen_ai.response.model | [anthropic], [autogen], [azure-ai-inference], [azure-openai], [claude-agent-sdk], [crewai], [dspy], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
 | gen_ai.response.time_to_first_chunk | (none) |
 | gen_ai.usage.cache_creation.input_tokens | [anthropic] |
 | gen_ai.usage.cache_read.input_tokens | [anthropic] |
-| gen_ai.usage.input_tokens | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai], [vertexai] |
-| gen_ai.usage.output_tokens | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai], [vertexai] |
+| gen_ai.usage.input_tokens | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [claude-agent-sdk], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai], [vertexai] |
+| gen_ai.usage.output_tokens | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [claude-agent-sdk], [cohere], [crewai], [dspy], [google-adk], [google-genai], [groq], [instructor], [langchain], [litellm], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai], [vertexai] |
 | gen_ai.usage.reasoning.output_tokens | (none) |
 | server.address | [anthropic], [autogen], [aws-bedrock], [azure-ai-inference], [azure-openai], [cohere], [crewai], [google-adk], [langchain], [llamaindex], [mistralai], [openai], [openai-agents], [pydantic-ai] |
 

--- a/reference/scenarios/claude-agent-sdk/data.json
+++ b/reference/scenarios/claude-agent-sdk/data.json
@@ -5,7 +5,11 @@
       "gen_ai.operation.name",
       "gen_ai.output.messages",
       "gen_ai.provider.name",
-      "gen_ai.response.finish_reasons"
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens"
     ]
   }
 }

--- a/reference/scenarios/claude-agent-sdk/scenario.py
+++ b/reference/scenarios/claude-agent-sdk/scenario.py
@@ -53,9 +53,6 @@ async def run_agent_query_reference():
         output_tokens = None
         async for message in query(prompt=prompt_text, options=options):
             if isinstance(message, AssistantMessage):
-                # claude-agent-sdk >=0.2 exposes fields directly on AssistantMessage
-                # (message.model, message.message_id, message.usage) rather than
-                # nesting them under message.message as in 0.1.x.
                 response_model = response_model or getattr(message, "model", None)
                 response_id = response_id or getattr(message, "message_id", None)
                 finish_reason = finish_reason or getattr(message, "stop_reason", None)

--- a/reference/scenarios/claude-agent-sdk/scenario.py
+++ b/reference/scenarios/claude-agent-sdk/scenario.py
@@ -58,12 +58,8 @@ async def run_agent_query_reference():
                 finish_reason = finish_reason or getattr(message, "stop_reason", None)
                 msg_usage = getattr(message, "usage", None)
                 if msg_usage is not None and input_tokens is None:
-                    input_tokens = getattr(msg_usage, "input_tokens", None) or (
-                        msg_usage.get("input_tokens") if isinstance(msg_usage, dict) else None
-                    )
-                    output_tokens = getattr(msg_usage, "output_tokens", None) or (
-                        msg_usage.get("output_tokens") if isinstance(msg_usage, dict) else None
-                    )
+                    input_tokens = msg_usage.get("input_tokens")
+                    output_tokens = msg_usage.get("output_tokens")
                 for block in message.content:
                     if isinstance(block, TextBlock):
                         output_text += block.text
@@ -72,8 +68,8 @@ async def run_agent_query_reference():
                 finish_reason = finish_reason or getattr(message, "stop_reason", None)
                 msg_usage = getattr(message, "usage", None)
                 if msg_usage is not None and input_tokens is None:
-                    input_tokens = getattr(msg_usage, "input_tokens", None)
-                    output_tokens = getattr(msg_usage, "output_tokens", None)
+                    input_tokens = msg_usage.get("input_tokens")
+                    output_tokens = msg_usage.get("output_tokens")
                 print(f"    -> result: turns={message.num_turns}")
         if response_model:
             span.set_attribute("gen_ai.response.model", response_model)

--- a/reference/scenarios/claude-agent-sdk/scenario.py
+++ b/reference/scenarios/claude-agent-sdk/scenario.py
@@ -53,15 +53,20 @@ async def run_agent_query_reference():
         output_tokens = None
         async for message in query(prompt=prompt_text, options=options):
             if isinstance(message, AssistantMessage):
-                raw = getattr(message, "message", None)
-                if raw is not None:
-                    response_model = response_model or getattr(raw, "model", None)
-                    response_id = response_id or getattr(raw, "id", None)
-                    finish_reason = finish_reason or getattr(raw, "stop_reason", None)
-                    raw_usage = getattr(raw, "usage", None)
-                    if raw_usage is not None:
-                        input_tokens = getattr(raw_usage, "input_tokens", None)
-                        output_tokens = getattr(raw_usage, "output_tokens", None)
+                # claude-agent-sdk >=0.2 exposes fields directly on AssistantMessage
+                # (message.model, message.message_id, message.usage) rather than
+                # nesting them under message.message as in 0.1.x.
+                response_model = response_model or getattr(message, "model", None)
+                response_id = response_id or getattr(message, "message_id", None)
+                finish_reason = finish_reason or getattr(message, "stop_reason", None)
+                msg_usage = getattr(message, "usage", None)
+                if msg_usage is not None and input_tokens is None:
+                    input_tokens = getattr(msg_usage, "input_tokens", None) or (
+                        msg_usage.get("input_tokens") if isinstance(msg_usage, dict) else None
+                    )
+                    output_tokens = getattr(msg_usage, "output_tokens", None) or (
+                        msg_usage.get("output_tokens") if isinstance(msg_usage, dict) else None
+                    )
                 for block in message.content:
                     if isinstance(block, TextBlock):
                         output_text += block.text

--- a/reference/scenarios/openai/data.json
+++ b/reference/scenarios/openai/data.json
@@ -12,6 +12,7 @@
       "gen_ai.request.presence_penalty",
       "gen_ai.request.seed",
       "gen_ai.request.stop_sequences",
+      "gen_ai.request.stream",
       "gen_ai.request.temperature",
       "gen_ai.request.top_p",
       "gen_ai.response.finish_reasons",

--- a/reference/scenarios/openai/scenario.py
+++ b/reference/scenarios/openai/scenario.py
@@ -140,6 +140,7 @@ def run_chat_streaming_reference(client):
         "gen_ai.operation.name": "chat",
         "gen_ai.provider.name": "openai",
         "gen_ai.request.model": request_model,
+        "gen_ai.request.stream": True,
     }
     if host:
         span_attributes_2["server.address"] = host


### PR DESCRIPTION
Two reference scenarios had `data.json` files that were out of sync with what their `scenario.py` implementations actually capture.

### claude-agent-sdk

`scenario.py` previously tried to read response fields from a nested `AssistantMessage.message.*` shape that does not exist on the current `claude-agent-sdk` Python SDK, so the entire response-attribute capture block was a silent no-op — `gen_ai.response.id`, `gen_ai.response.model`, and `gen_ai.usage.*` were never set on the span.

Update `scenario.py` to read the fields the SDK's `AssistantMessage` / `ResultMessage` dataclasses actually expose, and update `data.json` to list the attributes that are now captured:

| Attribute | Source |
|---|---|
| `gen_ai.response.id` | `AssistantMessage.message_id` |
| `gen_ai.response.model` | `AssistantMessage.model` |
| `gen_ai.response.finish_reasons` | `AssistantMessage.stop_reason` / `ResultMessage.stop_reason` |
| `gen_ai.usage.input_tokens` | `AssistantMessage.usage["input_tokens"]` / `ResultMessage.usage["input_tokens"]` |
| `gen_ai.usage.output_tokens` | `AssistantMessage.usage["output_tokens"]` / `ResultMessage.usage["output_tokens"]` |

`usage` is typed as `dict[str, Any] | None` on both message dataclasses, so it is accessed via `.get(...)` (not attribute access).

### openai

The streaming span in `scenario.py` sets `gen_ai.request.stream: True` but `data.json` was missing this attribute. Add it to `data.json` and add the explicit `gen_ai.request.stream = True` assignment to the span attributes dict in `scenario.py` so the intent is clear.

### Report

`reference/reports/inference-span.md` is regenerated to reflect the new coverage:

- `claude-agent-sdk` now appears in the `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, and `gen_ai.usage.output_tokens` rows.
- `openai` now appears in the `gen_ai.request.stream` row.

### Verification

```bash
cd reference/
uv run run-scenario claude-agent-sdk   # exit 0
uv run run-scenario openai             # exit 0
uv run update-reports                  # report updated
```