### PR TITLE
Use GraphQL to find the existing dashboard issue

### DIFF
--- a/.github/scripts/pull-request-dashboard/publish_dashboard.py
+++ b/.github/scripts/pull-request-dashboard/publish_dashboard.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from urllib.parse import quote
 
-from github_cli import detect_repo, gh_api, run_gh
+from github_cli import detect_repo, gh_graphql, run_gh
 from state import dashboard_markdown_path, set_state_dir
 import state_branch
 
@@ -17,18 +16,51 @@ DASHBOARD_TITLE = "Pull Request Dashboard"
 DASHBOARD_LABEL = "dashboard"
 
 
+# GraphQL is used instead of the REST `/repos/{repo}/issues` list endpoint
+# because that endpoint has been observed to omit pinned issues from its
+# results, which would cause this script to create a duplicate dashboard
+# issue instead of updating the existing one.
+_FIND_DASHBOARD_ISSUE_QUERY = """
+query ($owner: String!, $name: String!, $label: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $after
+      states: OPEN
+      filterBy: { labels: [$label] }
+      orderBy: { field: CREATED_AT, direction: ASC }
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes { number title }
+    }
+  }
+}
+"""
+
+
 def find_dashboard_issue(repo: str) -> int | None:
-    label = quote(DASHBOARD_LABEL, safe="")
-    issues = gh_api(f"/repos/{repo}/issues?state=open&labels={label}&per_page=100", paginate=True)
-    numbers = sorted(
-        issue["number"]
-        for issue in issues
-        if isinstance(issue, dict)
-        and issue.get("pull_request") is None
-        and issue.get("title") == DASHBOARD_TITLE
-        and isinstance(issue.get("number"), int)
-    )
-    return numbers[0] if numbers else None
+    owner, _, name = repo.partition("/")
+    numbers: list[int] = []
+    after: str | None = None
+    while True:
+        data = gh_graphql(
+            _FIND_DASHBOARD_ISSUE_QUERY,
+            {"owner": owner, "name": name, "label": DASHBOARD_LABEL, "after": after},
+        )
+        connection = (((data.get("data") or {}).get("repository") or {}).get("issues") or {})
+        for node in connection.get("nodes") or []:
+            if not isinstance(node, dict):
+                continue
+            if node.get("title") != DASHBOARD_TITLE:
+                continue
+            number = node.get("number")
+            if isinstance(number, int):
+                numbers.append(number)
+        page_info = connection.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor") or None
+    return min(numbers) if numbers else None
 
 
 def publish_dashboard(repo: str, dashboard_body: Path) -> None:

--- a/.github/scripts/pull-request-dashboard/publish_dashboard.py
+++ b/.github/scripts/pull-request-dashboard/publish_dashboard.py
@@ -17,9 +17,12 @@ DASHBOARD_LABEL = "dashboard"
 
 
 # GraphQL is used instead of the REST `/repos/{repo}/issues` list endpoint
-# because that endpoint has been observed to omit pinned issues from its
-# results, which would cause this script to create a duplicate dashboard
-# issue instead of updating the existing one.
+# because that endpoint has been observed to sometimes omit the existing
+# open, `dashboard`-labeled issue from its results (across every sort, page
+# size, and `since` variant), even though `GET /repos/{repo}/issues/<n>` and
+# the GraphQL `repository.issues` connection both still return it. When that
+# happens via REST, this script would create a duplicate dashboard issue
+# instead of updating the existing one.
 _FIND_DASHBOARD_ISSUE_QUERY = """
 query ($owner: String!, $name: String!, $label: String!, $after: String) {
   repository(owner: $owner, name: $name) {

--- a/.github/scripts/pull-request-dashboard/publish_dashboard.py
+++ b/.github/scripts/pull-request-dashboard/publish_dashboard.py
@@ -40,7 +40,6 @@ query ($owner: String!, $name: String!, $label: String!, $after: String) {
 
 def find_dashboard_issue(repo: str) -> int | None:
     owner, _, name = repo.partition("/")
-    numbers: list[int] = []
     after: str | None = None
     while True:
         data = gh_graphql(
@@ -49,14 +48,12 @@ def find_dashboard_issue(repo: str) -> int | None:
         )
         connection = data["data"]["repository"]["issues"]
         for node in connection["nodes"]:
-            if node["title"] != DASHBOARD_TITLE:
-                continue
-            numbers.append(node["number"])
+            if node["title"] == DASHBOARD_TITLE:
+                return node["number"]
         page_info = connection["pageInfo"]
         if not page_info["hasNextPage"]:
-            break
+            return None
         after = page_info["endCursor"]
-    return min(numbers) if numbers else None
 
 
 def publish_dashboard(repo: str, dashboard_body: Path) -> None:

--- a/.github/scripts/pull-request-dashboard/publish_dashboard.py
+++ b/.github/scripts/pull-request-dashboard/publish_dashboard.py
@@ -47,19 +47,15 @@ def find_dashboard_issue(repo: str) -> int | None:
             _FIND_DASHBOARD_ISSUE_QUERY,
             {"owner": owner, "name": name, "label": DASHBOARD_LABEL, "after": after},
         )
-        connection = (((data.get("data") or {}).get("repository") or {}).get("issues") or {})
-        for node in connection.get("nodes") or []:
-            if not isinstance(node, dict):
+        connection = data["data"]["repository"]["issues"]
+        for node in connection["nodes"]:
+            if node["title"] != DASHBOARD_TITLE:
                 continue
-            if node.get("title") != DASHBOARD_TITLE:
-                continue
-            number = node.get("number")
-            if isinstance(number, int):
-                numbers.append(number)
-        page_info = connection.get("pageInfo") or {}
-        if not page_info.get("hasNextPage"):
+            numbers.append(node["number"])
+        page_info = connection["pageInfo"]
+        if not page_info["hasNextPage"]:
             break
-        after = page_info.get("endCursor") or None
+        after = page_info["endCursor"]
     return min(numbers) if numbers else None
 
 


### PR DESCRIPTION
Use GraphQL in `find_dashboard_issue()` so a duplicate dashboard issue isn't created when REST temporarily hides the existing one.

Today the dashboard publisher created #196 even though #102 already exists, is open, and is labeled `dashboard`. The 13:02 UTC `publish-dashboard` job logged `creating dashboard issue`, meaning `find_dashboard_issue()` returned `None`. Direct inspection confirms GitHub's REST list-issues endpoint is currently omitting #102 from `/repos/{repo}/issues?state=open&labels=dashboard` (and from the unfiltered `?state=open` listing) across every sort/page-size/since variant, while `GET /repos/{repo}/issues/102` and the GraphQL `repository.issues(filterBy:{labels:["dashboard"]})` connection both return it. The 09:17 UTC scheduled run today still saw #102 via REST, so this looks like a sporadic index hiccup on GitHub's side rather than something the publisher script can detect.

This PR switches the lookup to a paginated GraphQL query, which has returned the pinned #102 consistently in every test. Verified locally that the new `find_dashboard_issue('open-telemetry/semantic-conventions-genai')` returns `102`.

Will close #196 once this is merged.