### PR TITLE
Add 'needs author feedback' label to help manage backlog

### DIFF
--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -18,12 +18,11 @@ jobs:
       github.event.comment.user.login == github.event.issue.user.login
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Remove labels
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh issue edit --remove-label "needs author feedback" $ISSUE_NUMBER
           gh issue edit --remove-label "stale" $ISSUE_NUMBER

--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     if: >
       contains(github.event.issue.labels.*.name, 'needs author feedback') &&
       github.event.comment.user.login == github.event.issue.user.login

--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -1,0 +1,29 @@
+name: Issue management - remove labels as needed
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  issue_comment:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs author feedback') &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Remove labels
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit --remove-label "needs author feedback" $ISSUE_NUMBER
+          gh issue edit --remove-label "stale" $ISSUE_NUMBER

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -1,0 +1,37 @@
+name: Issue management - run stale action
+
+on:
+  schedule:
+    # daily at 09:47 UTC
+    - cron: "47 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      contents: read
+      actions: write # because actions/stale deletes its old cache before saving new one
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      # Handle issues/PRs awaiting author feedback
+      # - After 14 days inactive: Adds stale label + comment
+      # - After 14 more days inactive: Closes
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          only-labels: "needs author feedback"
+          days-before-stale: 14
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been labeled as stale due to lack of activity and needing author feedback.
+            It will be automatically closed if there is no further activity over the next 14 days.
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has been labeled as stale due to lack of activity and needing author feedback.
+            It will be automatically closed if there is no further activity over the next 14 days.
+          operations-per-run: 1000

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-   group: ${{ github.workflow }}
-   cancel-in-progress: false
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -6,6 +6,10 @@ on:
     - cron: "47 9 * * *"
   workflow_dispatch:
 
+concurrency:
+   group: ${{ github.workflow }}
+   cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
To help with maintaining issue and PR backlog.

Triagers can add `needs author feedback` label to an issue or PR.

If author hasn't commented within 14 days after that, the `stale` label is automatically applied and a comment is left on the issue or PR that the issue will be automatically closed if there is no further activity in the next 14 days.