### PR TITLE
Clarify boundary between gen_ai.memory.records and gen_ai.retrieval.documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,9 @@
   ([#136](https://github.com/open-telemetry/semantic-conventions-genai/pull/136))
 
 ### 📚 Clarifications 📚
+
+- Clarify the boundary between `gen_ai.memory.records` and `gen_ai.retrieval.documents`:
+  the attribute follows the operation the caller invoked, not the backing store, so
+  `search_memory` spans use `gen_ai.memory.records` even when the memory store is
+  backed by a vector database.
+  ([#139](https://github.com/open-telemetry/semantic-conventions-genai/issues/139))

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -519,6 +519,9 @@ format is not supported and SHOULD be recorded in structured form otherwise.
 Each document object SHOULD contain at least the following properties:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
+The choice between this attribute and `gen_ai.memory.records` follows the
+operation the caller invoked, not the backing store.
+
 **[9] `gen_ai.retrieval.query.text`:**
 
 > [!Warning]
@@ -688,6 +691,9 @@ by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESS
 When the attribute is recorded on events, it MUST be recorded in structured
 form. When recorded on spans, it MAY be recorded as a JSON string if structured
 format is not supported and SHOULD be recorded in structured form otherwise.
+
+The choice between this attribute and `gen_ai.retrieval.documents` follows the
+operation the caller invoked, not the backing store.
 
 Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
 by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -96,6 +96,9 @@ When the attribute is recorded on events, it MUST be recorded in structured
 form. When recorded on spans, it MAY be recorded as a JSON string if structured
 format is not supported and SHOULD be recorded in structured form otherwise.
 
+The choice between this attribute and `gen_ai.retrieval.documents` follows the
+operation the caller invoked, not the backing store.
+
 Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
 by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
 
@@ -158,6 +161,9 @@ format is not supported and SHOULD be recorded in structured form otherwise.
 
 Each document object SHOULD contain at least the following properties:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
+
+The choice between this attribute and `gen_ai.memory.records` follows the
+operation the caller invoked, not the backing store.
 
 **[14] `gen_ai.retrieval.query.text`:**
 

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -507,6 +507,9 @@ attributes:
 
       Each document object SHOULD contain at least the following properties:
       `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
+
+      The choice between this attribute and `gen_ai.memory.records` follows the
+      operation the caller invoked, not the backing store.
     examples:
       - |
         [
@@ -576,6 +579,9 @@ attributes:
       When the attribute is recorded on events, it MUST be recorded in structured
       form. When recorded on spans, it MAY be recorded as a JSON string if structured
       format is not supported and SHOULD be recorded in structured form otherwise.
+
+      The choice between this attribute and `gen_ai.retrieval.documents` follows the
+      operation the caller invoked, not the backing store.
 
       Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
       by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.

--- a/schema-snapshot/registry.yaml
+++ b/schema-snapshot/registry.yaml
@@ -9434,6 +9434,9 @@ refinements:
         form. When recorded on spans, it MAY be recorded as a JSON string if structured
         format is not supported and SHOULD be recorded in structured form otherwise.
 
+        The choice between this attribute and `gen_ai.retrieval.documents` follows the
+        operation the caller invoked, not the backing store.
+
         Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
         by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
 
@@ -10094,6 +10097,9 @@ refinements:
 
         Each document object SHOULD contain at least the following properties:
         `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
+
+        The choice between this attribute and `gen_ai.memory.records` follows the
+        operation the caller invoked, not the backing store.
       provenance:
         path: ./model/gen-ai/registry.yaml
       requirement_level: opt_in
@@ -12105,6 +12111,9 @@ registry:
       form. When recorded on spans, it MAY be recorded as a JSON string if structured
       format is not supported and SHOULD be recorded in structured form otherwise.
 
+      The choice between this attribute and `gen_ai.retrieval.documents` follows the
+      operation the caller invoked, not the backing store.
+
       Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
       by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
 
@@ -12533,6 +12542,9 @@ registry:
 
       Each document object SHOULD contain at least the following properties:
       `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
+
+      The choice between this attribute and `gen_ai.memory.records` follows the
+      operation the caller invoked, not the backing store.
     provenance:
       path: ./model/gen-ai/registry.yaml
     stability: development
@@ -19789,6 +19801,9 @@ registry:
         form. When recorded on spans, it MAY be recorded as a JSON string if structured
         format is not supported and SHOULD be recorded in structured form otherwise.
 
+        The choice between this attribute and `gen_ai.retrieval.documents` follows the
+        operation the caller invoked, not the backing store.
+
         Instrumentations SHOULD NOT capture this attribute by default. Capture SHOULD be gated
         by an explicit user opt-in, for example `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
 
@@ -20447,6 +20462,9 @@ registry:
 
         Each document object SHOULD contain at least the following properties:
         `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
+
+        The choice between this attribute and `gen_ai.memory.records` follows the
+        operation the caller invoked, not the backing store.
       provenance:
         path: ./model/gen-ai/registry.yaml
       requirement_level: opt_in


### PR DESCRIPTION
Add a one-line note on each of `gen_ai.memory.records` and `gen_ai.retrieval.documents` stating that the choice between them follows the operation the caller invoked, not the backing store. Closes #139.