### PR TITLE
Clarify scope of `gen_ai.client.operation.duration` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
 
 ### 📚 Clarifications 📚
 
-- Clarify that `gen_ai.client.operation.duration` covers GenAI client operations such as
-  inference, embeddings, retrieval, memory, agent creation, and remote agent invocation,
-  and should not be recorded for internal operations such as tool execution, workflow
-  invocation, planning, or in-process agent invocation.
+- Clarify that `gen_ai.client.operation.duration` corresponds to the GenAI inference,
+  embeddings, retrieval, memory, create agent, and invoke agent client spans, and that
+  when the metric is reported alongside one of these spans its value should be the same
+  as the span duration.
+  ([#215](https://github.com/open-telemetry/semantic-conventions-genai/pull/215))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,8 @@
   ([#136](https://github.com/open-telemetry/semantic-conventions-genai/pull/136))
 
 ### 📚 Clarifications 📚
+
+- Clarify that `gen_ai.client.operation.duration` covers GenAI client operations such as
+  inference, embeddings, retrieval, memory, agent creation, and remote agent invocation,
+  and should not be recorded for internal operations such as tool execution, workflow
+  invocation, planning, or in-process agent invocation.

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -179,7 +179,16 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [0.01, 0.02, 
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
 | `gen_ai.client.operation.duration` | Histogram | `s` | GenAI client operation duration. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
-**[1]:** This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
+**[1]:** This metric corresponds to the GenAI client spans:
+[Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+[Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+[Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+[Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+[Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+When this metric is reported alongside one of these spans, the metric value
+SHOULD be the same as the span duration.
 
 **Attributes:**
 

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -177,7 +177,9 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [0.01, 0.02, 
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.client.operation.duration` | Histogram | `s` | GenAI operation duration. | ![Development](https://img.shields.io/badge/-development-blue) | |
+| `gen_ai.client.operation.duration` | Histogram | `s` | GenAI client operation duration. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
+
+**[1]:** This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
 
 **Attributes:**
 

--- a/docs/gen-ai/openai.md
+++ b/docs/gen-ai/openai.md
@@ -417,7 +417,9 @@ Measures the to complete an operation following the common [gen_ai.client.operat
 
 | Name | Instrument Type | Unit (UCUM) | Description | Stability | Entity Associations |
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
-| `gen_ai.client.operation.duration` | Histogram | `s` | OpenAI-specific extension to `gen_ai.client.operation.duration`. Adds `openai.response.service_tier` and `openai.response.system_fingerprint` when the provider is `openai`. | ![Development](https://img.shields.io/badge/-development-blue) | |
+| `gen_ai.client.operation.duration` | Histogram | `s` | OpenAI-specific extension to `gen_ai.client.operation.duration`. Adds `openai.response.service_tier` and `openai.response.system_fingerprint` when the provider is `openai`. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
+
+**[1]:** This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
 
 **Attributes:**
 

--- a/docs/gen-ai/openai.md
+++ b/docs/gen-ai/openai.md
@@ -419,7 +419,16 @@ Measures the to complete an operation following the common [gen_ai.client.operat
 | -------- | --------------- | ----------- | -------------- | --------- | ------ |
 | `gen_ai.client.operation.duration` | Histogram | `s` | OpenAI-specific extension to `gen_ai.client.operation.duration`. Adds `openai.response.service_tier` and `openai.response.system_fingerprint` when the provider is `openai`. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
-**[1]:** This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
+**[1]:** This metric corresponds to the GenAI client spans:
+[Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+[Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+[Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+[Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+[Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+When this metric is reported alongside one of these spans, the metric value
+SHOULD be the same as the span duration.
 
 **Attributes:**
 

--- a/model/gen-ai/metrics.yaml
+++ b/model/gen-ai/metrics.yaml
@@ -33,7 +33,12 @@ metrics:
   - name: gen_ai.client.operation.duration
     instrument: histogram
     unit: "s"
-    brief: 'GenAI operation duration.'
+    brief: 'GenAI client operation duration.'
+    note: >
+      This metric covers GenAI client operations such as inference, embeddings, retrieval,
+      memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for
+      internal operations such as tool execution, workflow invocation, planning, or
+      in-process agent invocation.
     stability: development
     annotations:
       code_generation:

--- a/model/gen-ai/metrics.yaml
+++ b/model/gen-ai/metrics.yaml
@@ -34,11 +34,17 @@ metrics:
     instrument: histogram
     unit: "s"
     brief: 'GenAI client operation duration.'
-    note: >
-      This metric covers GenAI client operations such as inference, embeddings, retrieval,
-      memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for
-      internal operations such as tool execution, workflow invocation, planning, or
-      in-process agent invocation.
+    note: |
+      This metric corresponds to the GenAI client spans:
+      [Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+      [Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+      [Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+      [Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+      [Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+      and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+      When this metric is reported alongside one of these spans, the metric value
+      SHOULD be the same as the span duration.
     stability: development
     annotations:
       code_generation:

--- a/schema-snapshot/registry.yaml
+++ b/schema-snapshot/registry.yaml
@@ -1063,10 +1063,12 @@ refinements:
         conditionally_required: If `server.address` is set.
       stability: stable
       type: int
-    brief: GenAI operation duration.
+    brief: GenAI client operation duration.
     id: gen_ai.client.operation.duration
     instrument: histogram
     name: gen_ai.client.operation.duration
+    note: |
+      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development
@@ -3854,6 +3856,8 @@ refinements:
     id: openai.client.operation.duration
     instrument: histogram
     name: gen_ai.client.operation.duration
+    note: |
+      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development
@@ -14078,9 +14082,11 @@ registry:
         conditionally_required: If `server.address` is set.
       stability: stable
       type: int
-    brief: GenAI operation duration.
+    brief: GenAI client operation duration.
     instrument: histogram
     name: gen_ai.client.operation.duration
+    note: |
+      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development

--- a/schema-snapshot/registry.yaml
+++ b/schema-snapshot/registry.yaml
@@ -1068,7 +1068,16 @@ refinements:
     instrument: histogram
     name: gen_ai.client.operation.duration
     note: |
-      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
+      This metric corresponds to the GenAI client spans:
+      [Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+      [Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+      [Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+      [Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+      [Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+      and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+      When this metric is reported alongside one of these spans, the metric value
+      SHOULD be the same as the span duration.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development
@@ -3857,7 +3866,16 @@ refinements:
     instrument: histogram
     name: gen_ai.client.operation.duration
     note: |
-      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
+      This metric corresponds to the GenAI client spans:
+      [Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+      [Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+      [Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+      [Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+      [Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+      and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+      When this metric is reported alongside one of these spans, the metric value
+      SHOULD be the same as the span duration.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development
@@ -14086,7 +14104,16 @@ registry:
     instrument: histogram
     name: gen_ai.client.operation.duration
     note: |
-      This metric covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation. It SHOULD NOT be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.
+      This metric corresponds to the GenAI client spans:
+      [Inference](/docs/gen-ai/gen-ai-spans.md#inference),
+      [Embeddings](/docs/gen-ai/gen-ai-spans.md#embeddings),
+      [Retrieval](/docs/gen-ai/gen-ai-spans.md#retrievals),
+      [Memory](/docs/gen-ai/gen-ai-spans.md#memory),
+      [Create Agent](/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span),
+      and [Invoke Agent Client](/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span).
+
+      When this metric is reported alongside one of these spans, the metric value
+      SHOULD be the same as the span duration.
     provenance:
       path: ./model/gen-ai/metrics.yaml
     stability: development


### PR DESCRIPTION
Related to #93

Clarify that `gen_ai.client.operation.duration` covers GenAI client operations such as inference, embeddings, retrieval, memory, agent creation, and remote agent invocation, and should not be recorded for internal operations such as tool execution, workflow invocation, planning, or in-process agent invocation.