### PR TITLE
Clarify GenAI span duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,7 @@
   ([#136](https://github.com/open-telemetry/semantic-conventions-genai/pull/136))
 
 ### 📚 Clarifications 📚
+
+- Clarify that a GenAI span SHOULD cover the duration of the corresponding call
+  as if it was observed by the caller, including any retries.
+  ([#216](https://github.com/open-telemetry/semantic-conventions-genai/pull/216))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,6 @@
 
 ### 📚 Clarifications 📚
 
-- Clarify that a GenAI span SHOULD cover the duration of the corresponding call
-  as if it was observed by the caller, including any retries.
+- Clarify that a GenAI span SHOULD cover the duration of the operation
+  as observed by the caller, including any retries.
   ([#216](https://github.com/open-telemetry/semantic-conventions-genai/pull/216))

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -24,6 +24,15 @@ linkTitle: Spans
 
 ## Spans
 
+GenAI spans represent logical operations as observed by the caller.
+They SHOULD cover the duration of the operation, starting when it is
+initiated and ending when the response is fully received or the operation
+is terminated due to an error or cancellation.
+
+If a transient issue happened and was retried within the operation, the
+corresponding span SHOULD cover the duration of the logical operation with
+all retries.
+
 ### Inference
 
 <!-- weaver .registry.spans[] | select(.type == "gen_ai.inference.client") -->

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -29,9 +29,9 @@ They SHOULD cover the duration of the operation, starting when it is
 initiated and ending when the response is fully received or the operation
 is terminated due to an error or cancellation.
 
-If a transient issue happened and was retried within the operation, the
-corresponding span SHOULD cover the duration of the logical operation with
-all retries.
+If a transient issue happened and the request was retried automatically, the
+corresponding span SHOULD cover the duration of the logical operation with all
+retries.
 
 ### Inference
 


### PR DESCRIPTION
Clarifies that a GenAI span SHOULD cover the duration of the corresponding call as observed by the caller, including retries. Mirrors the existing wording in the RPC / database semantic conventions.

Resolves #9.