### PR TITLE
Restrict GitHub Actions renovate schedule to a 4-hour window

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,8 +50,9 @@
         ".github/**"
       ],
       "schedule": [
-        "* * 2 * *"
-      ]
+        "* 0-3 2 * *" // 2nd of the month, midnight–4am
+      ],
+      "timezone": "America/Los_Angeles"
     }
   ],
   "labels": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,7 @@
       "groupName": "reference implementation dependencies (non-major)",
       "commitMessageTopic": "reference implementation dependencies (non-major)",
       "schedule": [
-        "* 0-3 * * 2" // Tuesdays, midnight–4am
+        "* 0-3 * * 2" // Tuesdays, 00:00–03:59 America/Los_Angeles
       ],
       "timezone": "America/Los_Angeles"
     },
@@ -50,7 +50,7 @@
         ".github/**"
       ],
       "schedule": [
-        "* 0-3 2 * *" // 2nd of the month, midnight–4am
+        "* 0-3 2 * *" // 2nd of the month, 00:00–03:59 America/Los_Angeles
       ],
       "timezone": "America/Los_Angeles"
     }


### PR DESCRIPTION
This will avoid us merging one PR (https://github.com/open-telemetry/semantic-conventions-genai/pull/228) only for Renovate to open another PR the same day (https://github.com/open-telemetry/semantic-conventions-genai/pull/234).