### PR TITLE
Route approved PRs with a pending reviewer thread to Waiting on approvers

### DIFF
--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -584,15 +584,20 @@ def route_pr(facts: dict[str, Any], classifications: list[dict[str, Any]]) -> st
     #      route to.
     #   2. Any single thread waiting on the author -> "author".
     #   3. Otherwise any thread waiting on something external -> "external".
-    #   4. Otherwise the current approval count decides: at least two approvals
-    #      -> ready for a maintainer to merge; fewer -> still waiting on approvers
-    #      (whether or not a thread is currently pending on a reviewer).
+    #   4. Otherwise any thread pending on a reviewer -> "approver". An open
+    #      reviewer-owed thread outranks the approval count: even an approved PR
+    #      is not merge-ready while an approver still owes a follow-up, because
+    #      that response may change their stance.
+    #   5. Otherwise the current approval count decides: at least two approvals
+    #      -> ready for a maintainer to merge; fewer -> still waiting on approvers.
     if facts.get("is_otelbot_author"):
         return "external" if counts["external"] else "approver"
     if counts["author"]:
         return "author"
     if counts["external"]:
         return "external"
+    if counts["reviewer"]:
+        return "approver"
     if facts.get("approval_count", 0) >= 2:
         return "maintainer"
     return "approver"

--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -578,27 +578,27 @@ def action_counts(classifications: list[dict[str, Any]]) -> dict[str, int]:
 
 def route_pr(facts: dict[str, Any], classifications: list[dict[str, Any]]) -> str:
     counts = action_counts(classifications)
+    # otelbot PRs have no human author, so an author-owed thread points at
+    # nobody who can act; skip that check for them. They also reach merge-ready
+    # on a single approval (these are low-risk dependency-bump PRs).
+    is_otelbot = facts.get("is_otelbot_author")
     # Precedence:
-    #   1. otelbot PRs are always either "external" (if any thread points
-    #      outside the repo) or "approver" — they have no human author to
-    #      route to.
-    #   2. Any single thread waiting on the author -> "author".
-    #   3. Otherwise any thread waiting on something external -> "external".
-    #   4. Otherwise any thread pending on a reviewer -> "approver". An open
+    #   1. A thread waiting on the author -> "author".
+    #   2. Otherwise a thread waiting on something external -> "external".
+    #   3. Otherwise a thread pending on a reviewer -> "approver". An open
     #      reviewer-owed thread outranks the approval count: even an approved PR
     #      is not merge-ready while an approver still owes a follow-up, because
     #      that response may change their stance.
-    #   5. Otherwise the current approval count decides: at least two approvals
-    #      -> ready for a maintainer to merge; fewer -> still waiting on approvers.
-    if facts.get("is_otelbot_author"):
-        return "external" if counts["external"] else "approver"
-    if counts["author"]:
+    #   4. Otherwise the approval count decides: enough approvals -> ready for a
+    #      maintainer to merge (two normally, one for low-risk otelbot PRs);
+    #      fewer -> still waiting on approvers.
+    if counts["author"] and not is_otelbot:
         return "author"
     if counts["external"]:
         return "external"
     if counts["reviewer"]:
         return "approver"
-    if facts.get("approval_count", 0) >= 2:
+    if facts.get("approval_count", 0) >= (1 if is_otelbot else 2):
         return "maintainer"
     return "approver"
 


### PR DESCRIPTION
PRs #211 and #212 each had two approvals but also an open thread where an approver asked a question and the author replied with a follow-up question — so the next action was actually back on the approver, but the dashboard listed them as waiting on maintainers.

Now an open reviewer-owed thread routes to "Waiting on approvers" regardless of approval count: an approved PR is not merge-ready while an approver still owes a follow-up.

This PR also lowers otelbot PRs to merge-ready on a single approval.