### PR TITLE
Add Reviewers column to PR dashboard

### DIFF
--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -108,6 +108,21 @@ survive into the cached dashboard state (see ``stored_result``).
                                                   or PR creation time.
     waiting_age_basis               str           Which heuristic chose
                                                   waiting_since.
+    reviewers                       list[dict]    Reviewers to display (added by
+                                                  add_reviewers). Each entry is
+                                                  {"login": str, "approved": bool,
+                                                  "approved_non_team": bool,
+                                                  "changes_requested": bool,
+                                                  "open_thread": bool}; approved
+                                                  means an approver-team member
+                                                  is in the APPROVED state,
+                                                  approved_non_team means someone
+                                                  outside the team approved,
+                                                  changes_requested means an
+                                                  approver-team member's latest
+                                                  review is CHANGES_REQUESTED,
+                                                  open_thread means they own an
+                                                  unresolved discussion thread.
 
 Stage-2 fields are absent on failure paths (failed is True). Human-readable
 ``age`` strings (e.g. ``3h``) are derived at render time from these
@@ -364,9 +379,22 @@ def latest_substantive_activity(events: list[dict[str, Any]], actor_roles: set[s
 
 
 def current_approval_count(events: list[dict[str, Any]]) -> int:
+    approvers = approver_logins(events)
+    return sum(
+        1
+        for reviewer, state in latest_review_states(events).items()
+        if state == "APPROVED" and reviewer in approvers
+    )
+
+
+def approver_logins(events: list[dict[str, Any]]) -> set[str]:
+    return {event["actor"] for event in events if event.get("actor_role") == "approver" and event.get("actor")}
+
+
+def latest_review_states(events: list[dict[str, Any]]) -> dict[str, str]:
     latest_by_reviewer: dict[str, tuple[str, str]] = {}
     for event in events:
-        if event.get("kind") != "review-state" or event.get("actor_role") != "approver":
+        if event.get("kind") != "review-state":
             continue
         reviewer = event.get("actor") or ""
         submitted_at = event.get("timestamp") or ""
@@ -376,7 +404,21 @@ def current_approval_count(events: list[dict[str, Any]]) -> int:
         previous = latest_by_reviewer.get(reviewer)
         if previous is None or submitted_at >= previous[0]:
             latest_by_reviewer[reviewer] = (submitted_at, state)
-    return sum(1 for _, state in latest_by_reviewer.values() if state == "APPROVED")
+    return {reviewer: state for reviewer, (_, state) in latest_by_reviewer.items()}
+
+
+def commenting_reviewers(events: list[dict[str, Any]]) -> set[str]:
+    # Approver-team members who have participated on the PR in any way: an
+    # issue comment, an inline review comment, or a submitted review. This
+    # surfaces engaged reviewers even when they have neither approved nor own
+    # an open thread.
+    return {
+        event["actor"]
+        for event in events
+        if event.get("actor_role") == "approver"
+        and event.get("kind") in ("issue-comment", "review-comment", "review-state")
+        and event.get("actor")
+    }
 
 
 def compute_facts(
@@ -657,6 +699,71 @@ def add_wait_age_facts(
     facts["waiting_age_basis"] = basis
 
 
+# Thread actions that count as an open, unresolved discussion. A reviewer who
+# commented in such a thread is not yet satisfied, even if they have approved.
+# "none" means no follow-up is needed, so it does not block a clear check.
+OPEN_THREAD_ACTIONS = {"author", "reviewer", "external", "unclear"}
+
+
+def reviewers_with_open_threads(
+    threads: list[dict[str, Any]],
+    classifications: list[dict[str, Any]],
+) -> set[str]:
+    by_id = threads_by_id(threads)
+    logins: set[str] = set()
+    for c in classifications:
+        action = normalize_thread_action((c.get("decision") or {}).get("thread_action") or "")
+        if action not in OPEN_THREAD_ACTIONS:
+            continue
+        thread = by_id.get(c.get("thread_id") or "")
+        if not thread:
+            continue
+        for comment in thread.get("comments") or []:
+            if comment.get("actor_role") in ("approver", "outsider") and comment.get("actor"):
+                logins.add(comment["actor"])
+    return logins
+
+
+def add_reviewers(
+    facts: dict[str, Any],
+    events: list[dict[str, Any]],
+    threads: list[dict[str, Any]],
+    classifications: list[dict[str, Any]],
+) -> None:
+    # Reviewers to display in the dashboard, each flagged with their review
+    # stance: approved (by an approver-team member), approved_non_team (an
+    # approval from someone outside the team), changes_requested (an
+    # approver-team member's latest review blocks), and open_thread (they own
+    # an unresolved discussion thread). The renderer turns these into icons.
+    # Reviewers are everyone who reviewed, owns an open thread, otherwise
+    # commented, or is a PR assignee, sorted alphabetically (case-insensitive).
+    states = latest_review_states(events)
+    approvers = approver_logins(events)
+    approved = {r for r, s in states.items() if s == "APPROVED" and r in approvers}
+    approved_non_team = {r for r, s in states.items() if s == "APPROVED" and r not in approvers}
+    changes_requested = {r for r, s in states.items() if s == "CHANGES_REQUESTED" and r in approvers}
+    with_open = reviewers_with_open_threads(threads, classifications)
+    candidates = (
+        approved
+        | approved_non_team
+        | changes_requested
+        | with_open
+        | commenting_reviewers(events)
+        | set(facts.get("assignees") or [])
+    )
+    candidates.discard("")
+    facts["reviewers"] = [
+        {
+            "login": login,
+            "approved": login in approved,
+            "approved_non_team": login in approved_non_team,
+            "changes_requested": login in changes_requested,
+            "open_thread": login in with_open,
+        }
+        for login in sorted(candidates, key=str.lower)
+    ]
+
+
 # ---------------------------------------------------------------- main
 
 
@@ -693,6 +800,7 @@ def build_pr_result(
             }
         route = route_pr(facts, classifications)
         add_wait_age_facts(facts, route, threads, classifications)
+        add_reviewers(facts, events, threads, classifications)
         return {
             "pr_number": number,
             "pr_title": raw["pr"].get("title") or "",

--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -388,7 +388,11 @@ def current_approval_count(events: list[dict[str, Any]]) -> int:
 
 
 def approver_logins(events: list[dict[str, Any]]) -> set[str]:
-    return {event["actor"] for event in events if event.get("actor_role") == "approver" and event.get("actor")}
+    return {
+        event["actor"]
+        for event in events
+        if event.get("actor_role") == "approver" and event.get("actor")
+    }
 
 
 def latest_review_states(events: list[dict[str, Any]]) -> dict[str, str]:

--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -14,7 +14,7 @@ import urllib.request
 from utils import activity_age, format_ts, parse_ts
 
 
-APPROVER_FOLLOW_UP_SECONDS = 24 * 60 * 60
+REVIEWER_FOLLOW_UP_SECONDS = 24 * 60 * 60
 SLACK_WEBHOOK_RETRY_ATTEMPTS = 3
 SLACK_WEBHOOK_RETRY_DELAY_SECONDS = 1.0
 
@@ -74,16 +74,16 @@ def post_slack_webhook(message: str, webhook_url: str) -> None:
         return
 
 
-def slack_message(repo: str, result: dict[str, Any], assignee_mention: str, kind: str) -> str:
+def slack_message(repo: str, result: dict[str, Any], reviewer_mentions: str, kind: str) -> str:
     facts = result.get("facts") or {}
     number = result.get("pr_number")
     url = result.get("pr_url") or f"https://github.com/{repo}/pull/{number}"
     if kind == "follow-up":
         waiting_age = activity_age(parse_ts(facts.get("waiting_since") or ""))
-        lead = f"is waiting on approvers for {waiting_age}"
+        lead = f"is waiting on reviewers for {waiting_age}"
     else:
-        lead = "moved to waiting on approvers"
-    return f"{assignee_mention} <{url}|PR #{number}> {lead}"
+        lead = "moved to waiting on reviewers"
+    return f"{reviewer_mentions} <{url}|PR #{number}> {lead}"
 
 
 def pending_notification_kind(
@@ -101,29 +101,37 @@ def pending_notification_kind(
         return "initial"
     if current_waiting_since > last_notified:
         return "initial"
-    if now.weekday() < 5 and (now - last_notified).total_seconds() >= APPROVER_FOLLOW_UP_SECONDS:
+    if now.weekday() < 5 and (now - last_notified).total_seconds() >= REVIEWER_FOLLOW_UP_SECONDS:
         return "follow-up"
     return None
+
+
+def reviewer_logins_for_notification(facts: dict[str, Any]) -> list[str]:
+    return [
+        str(reviewer.get("login") or "")
+        for reviewer in (facts.get("reviewers") or [])
+        if isinstance(reviewer, dict) and reviewer.get("login")
+    ]
 
 
 def send_slack_notification(
     repo: str,
     result: dict[str, Any],
-    assignees: list[str],
+    reviewers: list[str],
     kind: str,
     webhook_url: str,
-    assignee_mentions: str,
+    reviewer_mentions: str,
 ) -> str | None:
     number = result.get("pr_number")
     if not webhook_url:
         return "SLACK_WEBHOOK_URL is not set"
     try:
-        post_slack_webhook(slack_message(repo, result, assignee_mentions, kind), webhook_url)
+        post_slack_webhook(slack_message(repo, result, reviewer_mentions, kind), webhook_url)
     except Exception as e:
-        assignee_list = ", ".join(f"@{assignee}" for assignee in assignees)
-        return f"PR #{number}: failed to notify {assignee_list}: {e}"
+        reviewer_list = ", ".join(f"@{reviewer}" for reviewer in reviewers)
+        return f"PR #{number}: failed to notify {reviewer_list}: {e}"
     print(
-        f"  mentioned {', '.join(f'@{assignee}' for assignee in assignees)} on Slack for PR #{number} ({kind})",
+        f"  mentioned {', '.join(f'@{reviewer}' for reviewer in reviewers)} on Slack for PR #{number} ({kind})",
         file=sys.stderr,
     )
     return None
@@ -180,12 +188,12 @@ def next_notification_state(
             continue
 
         facts = result.get("facts") or {}
-        mapped_assignees = [
-            (a, slack_user_map[a.lower()])
-            for a in (facts.get("assignees") or [])
-            if a.lower() in slack_user_map
+        mapped_reviewers = [
+            (reviewer, slack_user_map[reviewer.lower()])
+            for reviewer in reviewer_logins_for_notification(facts)
+            if reviewer.lower() in slack_user_map
         ]
-        if not mapped_assignees:
+        if not mapped_reviewers:
             if previous_pr_state:
                 new_prs[pr_key] = previous_pr_state
             continue
@@ -201,9 +209,9 @@ def next_notification_state(
         }
 
         if kind:
-            assignees = [assignee for assignee, _ in mapped_assignees]
-            assignee_mentions = " ".join(f"<@{slack_user_id}>" for _, slack_user_id in mapped_assignees)
-            error = send_slack_notification(repo, result, assignees, kind, webhook_url, assignee_mentions)
+            reviewers = [reviewer for reviewer, _ in mapped_reviewers]
+            reviewer_mentions = " ".join(f"<@{slack_user_id}>" for _, slack_user_id in mapped_reviewers)
+            error = send_slack_notification(repo, result, reviewers, kind, webhook_url, reviewer_mentions)
             if error:
                 print(f"  warning: {error}", file=sys.stderr)
                 notification_errors.append(error)

--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -107,6 +107,8 @@ def pending_notification_kind(
 
 
 def reviewer_logins_for_notification(facts: dict[str, Any]) -> list[str]:
+    # Notify all displayed reviewers because one reviewer's comment may be
+    # relevant context for the others, even when only one person needs to act.
     return [
         str(reviewer.get("login") or "")
         for reviewer in (facts.get("reviewers") or [])

--- a/.github/scripts/pull-request-dashboard/publish_dashboard.py
+++ b/.github/scripts/pull-request-dashboard/publish_dashboard.py
@@ -59,6 +59,13 @@ def find_dashboard_issue(repo: str) -> int | None:
         after = page_info["endCursor"]
 
 
+def dashboard_issue_url(repo: str) -> str:
+    number = find_dashboard_issue(repo)
+    if number is None:
+        raise RuntimeError(f"dashboard issue not found in {repo}")
+    return f"https://github.com/{repo}/issues/{number}"
+
+
 def publish_dashboard(repo: str, dashboard_body: Path) -> None:
     if not dashboard_body.exists():
         raise RuntimeError(f"dashboard markdown not found: {dashboard_body}")
@@ -97,13 +104,24 @@ def publish_dashboard(repo: str, dashboard_body: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--print-dashboard-url",
+        action="store_true",
+        help="print the existing dashboard issue URL and exit",
+    )
+    parser.add_argument(
         "--state-branch",
-        required=True,
         help="git branch used for workflow state",
     )
     args = parser.parse_args()
 
     repo = detect_repo()
+    if args.print_dashboard_url:
+        print(dashboard_issue_url(repo))
+        return 0
+
+    if not args.state_branch:
+        parser.error("--state-branch is required unless --print-dashboard-url is set")
+
     with state_branch.temporary_state_dir() as state_dir:
         set_state_dir(state_dir)
         state_branch.configure_git()

--- a/.github/scripts/pull-request-dashboard/render.py
+++ b/.github/scripts/pull-request-dashboard/render.py
@@ -105,21 +105,8 @@ def reviewer_display_name(login: str) -> str:
     return REVIEWER_DISPLAY_NAMES.get(login, login)
 
 
-def reviewers_cell_text(facts: dict[str, Any], pr: dict[str, Any]) -> str:
-    reviewers = facts.get("reviewers")
-    if reviewers is None:
-        # Failed builds have no classifications; fall back to bare assignees.
-        assignees = facts.get("assignees") or [actor_login(a) for a in (pr.get("assignees") or [])]
-        reviewers = [
-            {
-                "login": a,
-                "approved": False,
-                "approved_non_team": False,
-                "changes_requested": False,
-                "open_thread": False,
-            }
-            for a in assignees
-        ]
+def reviewers_cell_text(facts: dict[str, Any]) -> str:
+    reviewers = facts.get("reviewers") or []
     parts = []
     for reviewer in reviewers:
         login = _md_escape(reviewer_display_name(reviewer.get("login") or ""))
@@ -210,7 +197,7 @@ def render_pr_tables(prs: list[dict[str, Any]], results: dict[int, dict[str, Any
             res = results.get(number) or {}
             facts = res.get("facts") or {}
             author = facts.get("author") or actor_login(pr.get("author") or {})
-            reviewers_cell = reviewers_cell_text(facts, pr)
+            reviewers_cell = reviewers_cell_text(facts)
             activity_cell = age_cell(facts)
             pr_cell = f"[{title} (#{number})]({url})"
             out.append(

--- a/.github/scripts/pull-request-dashboard/render.py
+++ b/.github/scripts/pull-request-dashboard/render.py
@@ -80,12 +80,14 @@ def age_cell(facts: dict[str, Any]) -> str:
     return activity_age(_age_ts(facts))
 
 
+WORD_JOINER = "\u2060"
+
+
 def reviewer_icon(reviewer: dict[str, Any]) -> str:
     if reviewer.get("changes_requested"):
         return "🔴"
     if reviewer.get("approved"):
-        # Word joiner (U+2060) keeps the two emoji on the same line.
-        return "💬⁠✅" if reviewer.get("open_thread") else "✅"
+        return f"💬{WORD_JOINER}✅" if reviewer.get("open_thread") else "✅"
     if reviewer.get("approved_non_team"):
         # A black/gray check distinguishes a non-code-owner approval from a
         # code-owner approval; only code-owner approvals count toward merge.

--- a/.github/scripts/pull-request-dashboard/render.py
+++ b/.github/scripts/pull-request-dashboard/render.py
@@ -163,7 +163,7 @@ def render_pr_tables(prs: list[dict[str, Any]], results: dict[int, dict[str, Any
         f"partly performed by an LLM ([source]({source_url})) and could contain mistakes.",
         ">",
         "> Reviewers column: ✅ approved · ✔️ approved (non-code-owner) · "
-        "💬 open thread · 🔴 changes requested.",
+        "> 💬 open thread · 🔴 changes requested.",
         "",
     ]
 

--- a/.github/scripts/pull-request-dashboard/render.py
+++ b/.github/scripts/pull-request-dashboard/render.py
@@ -8,7 +8,7 @@ from utils import actor_login, activity_age, parse_ts, seconds_since
 
 ROUTE_LABELS = {
     "maintainer": "Waiting on maintainers",
-    "approver": "Waiting on approvers",
+    "approver": "Waiting on reviewers",
     "author": "Waiting on authors",
     "external": "Waiting on external",
     "transient-failure": "Transient GitHub failure retrieving PR data",
@@ -80,9 +80,55 @@ def age_cell(facts: dict[str, Any]) -> str:
     return activity_age(_age_ts(facts))
 
 
-def approval_marks(facts: dict[str, Any]) -> str:
-    count = facts.get("approval_count", 0)
-    return "" if count <= 0 else " " + "✅" * count
+def reviewer_icon(reviewer: dict[str, Any]) -> str:
+    if reviewer.get("changes_requested"):
+        return "🔴"
+    if reviewer.get("approved"):
+        # Word joiner (U+2060) keeps the two emoji on the same line.
+        return "💬⁠✅" if reviewer.get("open_thread") else "✅"
+    if reviewer.get("approved_non_team"):
+        # A black/gray check distinguishes a non-code-owner approval from a
+        # code-owner approval; only code-owner approvals count toward merge.
+        return "💬⁠✔️" if reviewer.get("open_thread") else "✔️"
+    if reviewer.get("open_thread"):
+        return "💬"
+    return ""
+
+
+# Friendlier display names for bot reviewers whose login is verbose.
+REVIEWER_DISPLAY_NAMES = {
+    "copilot-pull-request-reviewer": "Copilot",
+}
+
+
+def reviewer_display_name(login: str) -> str:
+    return REVIEWER_DISPLAY_NAMES.get(login, login)
+
+
+def reviewers_cell_text(facts: dict[str, Any], pr: dict[str, Any]) -> str:
+    reviewers = facts.get("reviewers")
+    if reviewers is None:
+        # Failed builds have no classifications; fall back to bare assignees.
+        assignees = facts.get("assignees") or [actor_login(a) for a in (pr.get("assignees") or [])]
+        reviewers = [
+            {
+                "login": a,
+                "approved": False,
+                "approved_non_team": False,
+                "changes_requested": False,
+                "open_thread": False,
+            }
+            for a in assignees
+        ]
+    parts = []
+    for reviewer in reviewers:
+        login = _md_escape(reviewer_display_name(reviewer.get("login") or ""))
+        if not login:
+            continue
+        icon = reviewer_icon(reviewer)
+        # Join name and icon with a non-breaking space so they never wrap apart.
+        parts.append(f"{login}&nbsp;{icon}" if icon else login)
+    return "<br>".join(parts)
 
 
 def _neutralize_code_fence(s: str) -> str:
@@ -126,6 +172,9 @@ def render_pr_tables(prs: list[dict[str, Any]], results: dict[int, dict[str, Any
         "> Open non-draft PRs grouped by who is expected to act next. Draft PRs are "
         "listed separately. The grouping is "
         f"partly performed by an LLM ([source]({source_url})) and could contain mistakes.",
+        ">",
+        "> Reviewers column: ✅ approved · ✔️ approved (non-code-owner) · "
+        "💬 open thread · 🔴 changes requested.",
         "",
     ]
 
@@ -152,7 +201,7 @@ def render_pr_tables(prs: list[dict[str, Any]], results: dict[int, dict[str, Any
         rows.sort(key=row_sort_key, reverse=True)
         out.append(f"## {ROUTE_LABELS.get(route, route)}")
         out.append("")
-        out.append("| PR | Author | Assignees | CI | Conflicts | Age |")
+        out.append("| PR | Author | Reviewers | CI | Conflicts | Age |")
         out.append("|---|---|---|:---:|:---:|:---:|")
         for pr in rows:
             number = pr["number"]
@@ -161,15 +210,11 @@ def render_pr_tables(prs: list[dict[str, Any]], results: dict[int, dict[str, Any
             res = results.get(number) or {}
             facts = res.get("facts") or {}
             author = facts.get("author") or actor_login(pr.get("author") or {})
-            assignees = facts.get("assignees") or [
-                actor_login(a) for a in (pr.get("assignees") or [])
-            ]
-            assignees_cell = _md_escape(", ".join(a for a in assignees if a))
+            reviewers_cell = reviewers_cell_text(facts, pr)
             activity_cell = age_cell(facts)
             pr_cell = f"[{title} (#{number})]({url})"
-            pr_cell += approval_marks(facts)
             out.append(
-                f"| {pr_cell} | {author} | {assignees_cell} | {ci_cell(facts)} | "
+                f"| {pr_cell} | {author} | {reviewers_cell} | {ci_cell(facts)} | "
                 f"{conflicts_cell(facts)} | {activity_cell} |"
             )
         out.append("")

--- a/.github/scripts/pull-request-dashboard/render.py
+++ b/.github/scripts/pull-request-dashboard/render.py
@@ -91,7 +91,7 @@ def reviewer_icon(reviewer: dict[str, Any]) -> str:
     if reviewer.get("approved_non_team"):
         # A black/gray check distinguishes a non-code-owner approval from a
         # code-owner approval; only code-owner approvals count toward merge.
-        return "💬⁠✔️" if reviewer.get("open_thread") else "✔️"
+        return f"💬{WORD_JOINER}✔️" if reviewer.get("open_thread") else "✔️"
     if reviewer.get("open_thread"):
         return "💬"
     return ""

--- a/.github/workflows/pull-request-dashboard.yml
+++ b/.github/workflows/pull-request-dashboard.yml
@@ -149,6 +149,11 @@ jobs:
     environment: protected
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          persist-credentials: false
+
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:

--- a/.github/workflows/pull-request-dashboard.yml
+++ b/.github/workflows/pull-request-dashboard.yml
@@ -187,17 +187,20 @@ jobs:
             exit 0
           fi
 
+          dashboard_url=$(python3 .github/scripts/pull-request-dashboard/publish_dashboard.py --print-dashboard-url)
+
           body=$(cat <<EOF
           ${MARKER}
           Copilot has reviewed this PR. Copilot's suggestions aren't always correct or applicable, so please evaluate each comment on its merits and then handle it in one of these ways:
 
           - click GitHub's "Apply suggestion" button (auto-resolves the thread);
           - reply that it was **applied** (ideally linking to the commit); or
-          - reply that it was **not applied**, with the reason.
+          - reply that it was **not applied**, with the reason; or
+          - reply with a question for reviewers.
 
-          Approvers rely on automation that flags a PR for human review once every Copilot comment has been replied to or marked as resolved, so keeping these threads up to date is what tells reviewers the PR is ready for another look.
+          Automation flags a PR for human review once every Copilot comment has a reply or is marked as resolved, so keeping these threads up to date helps reviewers know when the PR is ready.
 
-          Status across open PRs is visible on the [pull request dashboard](https://github.com/open-telemetry/semantic-conventions-genai/issues/102).
+          Status across open PRs is visible on the [pull request dashboard](${dashboard_url}).
           EOF
           )
 


### PR DESCRIPTION
Show per-reviewer status in the dashboard's Reviewers column with leading icons:

- ✅ approved (by a code owner)
- ✔️ approved (non-code-owner)
- 💬 open thread
- 🔴 changes requested

Example below:

-----------------------

> [!NOTE]
> Open non-draft PRs grouped by who is expected to act next. Draft PRs are listed separately. The grouping is partly performed by an LLM ([source](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/scripts/pull-request-dashboard/dashboard.py)) and could contain mistakes.
>
> Reviewers column: ✅ approved · ✔️ approved (non-code-owner) · 💬 open thread · 🔴 changes requested.

## Waiting on reviewers

| PR | Author | Reviewers | CI | Conflicts | Age |
|---|---|---|:---:|:---:|:---:|
| [gen-ai: model agent-to-agent handoff as execute_tool span (#98)](https://github.com/open-telemetry/semantic-conventions-genai/pull/98) | Krishnachaitanyakc | lmolkova<br>MikeGoldsmith&nbsp;🔴<br>trask&nbsp;💬 | ✅ | ❌ | 8d |
| [Clarify scope of `gen_ai.client.operation.duration` metric (#215)](https://github.com/open-telemetry/semantic-conventions-genai/pull/215) | trask | lmolkova | ✅ | ❌ | 6d |
| [semconv for a2a protocol (#195)](https://github.com/open-telemetry/semantic-conventions-genai/pull/195) | eternalcuriouslearner |  | ✅ | ✅ | 6d |
| [Generalize the `gen_ai.provider.name` description (#212)](https://github.com/open-telemetry/semantic-conventions-genai/pull/212) | trask | lmolkova&nbsp;✅<br>MikeGoldsmith&nbsp;💬⁠✅ | ✅ | ✅ | 9h |
| [Clarify that billed token counts should be reported for Cohere usage (#211)](https://github.com/open-telemetry/semantic-conventions-genai/pull/211) | trask | lmolkova&nbsp;✅<br>MikeGoldsmith&nbsp;💬⁠✅ | ✅ | ✅ | 9h |
| [Normalize requirement-level condition notes to capitalized sentences (#245)](https://github.com/open-telemetry/semantic-conventions-genai/pull/245) | trask |  | ✅ | ✅ | 8h |
| [Add gen_ai.agent.invocation.id attribute for invoke_agent spans (#250)](https://github.com/open-telemetry/semantic-conventions-genai/pull/250) | singankit |  | ✅ | ✅ | 2h |

## Waiting on authors

| PR | Author | Reviewers | CI | Conflicts | Age |
|---|---|---|:---:|:---:|:---:|
| [gen-ai: make input-messages BlobPart content optional and add stripped_reason (#144)](https://github.com/open-telemetry/semantic-conventions-genai/pull/144) | Mandark-droid | Copilot&nbsp;💬<br>trask | ✅ | ✅ | 24d |
| [Add gen_ai.server.inter_token_latency metric (#164)](https://github.com/open-telemetry/semantic-conventions-genai/pull/164) | Jwrede | lmolkova&nbsp;💬 | ✅ | ❌ | 17d |
| [Update dependency google-genai to v2 (#112)](https://github.com/open-telemetry/semantic-conventions-genai/pull/112) | app/renovate | DylanRussell&nbsp;💬<br>lmolkova&nbsp;✅ | ❌ | ✅ | 16d |
| [gen-ai: add evaluation operation name and gen_ai.evaluate.internal span (#185)](https://github.com/open-telemetry/semantic-conventions-genai/pull/185) | hippoley | Cirilla-zmh&nbsp;💬<br>Copilot&nbsp;💬<br>singankit&nbsp;💬 | ❌ | ✅ | 14d |
| [Add experimental GenAI context selection event (#190)](https://github.com/open-telemetry/semantic-conventions-genai/pull/190) | caioribeiroclw-pixel | Copilot&nbsp;💬<br>trask&nbsp;💬 | ❌ | ❌ | 13d |
| [Update dependency google-adk to v2 (#173)](https://github.com/open-telemetry/semantic-conventions-genai/pull/173) | app/renovate | MikeGoldsmith&nbsp;💬 | ❌ | ✅ | 8d |
| [Add prompt versioning and variable support to GenAI attributes (#179)](https://github.com/open-telemetry/semantic-conventions-genai/pull/179) | steverao | lmolkova<br>trask&nbsp;💬 | ✅ | ❌ | 8d |
| [Add gen_ai.agent.invocation.duration and gen_ai.tool.execution.duration metrics (#201)](https://github.com/open-telemetry/semantic-conventions-genai/pull/201) | pvlsirotkin | MikeGoldsmith&nbsp;🔴 | ✅ | ❌ | 7d |
| [gen-ai: add gen_ai.response.id to deepeval evaluation result event (#184)](https://github.com/open-telemetry/semantic-conventions-genai/pull/184) | hippoley | lmolkova&nbsp;✅<br>MikeGoldsmith&nbsp;🔴<br>trask | ✅ | ✅ | 7d |
| [gen-ai: add optional byte_size to multimodal content parts (#143)](https://github.com/open-telemetry/semantic-conventions-genai/pull/143) | Mandark-droid | Cirilla-zmh<br>trask&nbsp;💬 | ✅ | ✅ | 5d |
| [Add workflow node convention (#188)](https://github.com/open-telemetry/semantic-conventions-genai/pull/188) | RKest | lmolkova&nbsp;🔴<br>trask&nbsp;💬 | ✅ | ❌ | 5d |
| [Add modality, cache, and phase breakdowns for token usage (#197)](https://github.com/open-telemetry/semantic-conventions-genai/pull/197) | trask | alexmojaki&nbsp;💬<br>lmolkova&nbsp;💬<br>Nik-Reddy&nbsp;💬 | ✅ | ❌ | 5d |
| [semconv for compaction (#162)](https://github.com/open-telemetry/semantic-conventions-genai/pull/162) | eternalcuriouslearner | JWinermaSplunk&nbsp;💬<br>lmolkova&nbsp;💬⁠✅<br>trask | ✅ | ❌ | 3d |
| [Replace Jupiter notebook with models with python file and add CI check that json schemas are up-to-date (#226)](https://github.com/open-telemetry/semantic-conventions-genai/pull/226) | lmolkova | aabmass&nbsp;💬⁠✅<br>trask&nbsp;✅ | ✅ | ✅ | 2d |
| [Limit gen_ai.agent.id to stable / static identifiers (#242)](https://github.com/open-telemetry/semantic-conventions-genai/pull/242) | lmolkova | Copilot&nbsp;💬 | ✅ | ❌ | 20h |
| [Add gen_ai.agent.finish_reason attribute for agent loop termination (#238)](https://github.com/open-telemetry/semantic-conventions-genai/pull/238) | Nik-Reddy | Copilot&nbsp;💬<br>MikeGoldsmith&nbsp;🔴 | ✅ | ❌ | 11h |
| [Add gen_ai.agent.request.size and gen_ai.agent.response.size metrics (#202)](https://github.com/open-telemetry/semantic-conventions-genai/pull/202) | pvlsirotkin | Copilot&nbsp;💬<br>MikeGoldsmith&nbsp;🔴<br>trask | ✅ | ✅ | 11h |
| [Add gen_ai.workflow.steps metric (#203)](https://github.com/open-telemetry/semantic-conventions-genai/pull/203) | pvlsirotkin | MikeGoldsmith&nbsp;🔴<br>trask | ✅ | ✅ | 10h |

## Draft pull requests

| PR | Author | Updated |
|---|---|:---:|
| [proposal: agent.threat.detection.* attributes + event (closes #132) (#165)](https://github.com/open-telemetry/semantic-conventions-genai/pull/165) | eeee2345 | 13d |
| [genai: add `gen_ai.token.cache` and `gen_ai.token.reasoning` metric attributes (#96)](https://github.com/open-telemetry/semantic-conventions-genai/pull/96) | Nik-Reddy | 6d |
