### PR TITLE
Avoid repeated initial PR dashboard Slack notifications

### DIFF
--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -99,9 +99,11 @@ def pending_notification_kind(
     last_notified = parse_ts(previous_pr_state.get("last_notified_at") or "")
     if last_notified is None:
         return "initial"
+    if (now - last_notified).total_seconds() < REVIEWER_FOLLOW_UP_SECONDS:
+        return None
     if current_waiting_since > last_notified:
         return "initial"
-    if now.weekday() < 5 and (now - last_notified).total_seconds() >= REVIEWER_FOLLOW_UP_SECONDS:
+    if now.weekday() < 5:
         return "follow-up"
     return None
 

--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -99,11 +99,12 @@ def pending_notification_kind(
     last_notified = parse_ts(previous_pr_state.get("last_notified_at") or "")
     if last_notified is None:
         return "initial"
-    if (now - last_notified).total_seconds() < REVIEWER_FOLLOW_UP_SECONDS:
-        return None
+    elapsed_seconds = (now - last_notified).total_seconds()
     if current_waiting_since > last_notified:
+        if elapsed_seconds < REVIEWER_FOLLOW_UP_SECONDS:
+            return None
         return "initial"
-    if now.weekday() < 5:
+    if now.weekday() < 5 and elapsed_seconds >= REVIEWER_FOLLOW_UP_SECONDS:
         return "follow-up"
     return None
 


### PR DESCRIPTION
Avoid repeated initial PR dashboard Slack notifications when a PR's waiting timestamp advances shortly after an earlier ping. The notification cadence is now applied before treating a later waiting timestamp as a fresh initial notification, so author comments or edits cannot trigger another reviewer ping minutes later.