### PR TITLE
Fix PR dashboard reaction query limit

### DIFF
--- a/.github/scripts/pull-request-dashboard/classification.py
+++ b/.github/scripts/pull-request-dashboard/classification.py
@@ -58,6 +58,11 @@ Guidance:
     handed the ball back. If the author answers the thread while mentioning
     separate follow-up work, treat that as a completed reply unless they say
     the current PR is still waiting on that work.
+  - A comment may include positive_reactors: participants who added a positive
+    reaction to that comment. A positive reaction can acknowledge a completed
+    reply, but it does not by itself mean no one has follow-up. For example,
+    if the author says they will still make a change in this PR and a reviewer
+    reacts positively, classify as author.
 
 Respond with a single JSON object and nothing else:
 {{"thread_action": "author" | "reviewer" | "external" | "none" | "unclear", "reason": "short explanation grounded in this thread"}}
@@ -166,6 +171,7 @@ def thread_prompt_input(thread: dict[str, Any]) -> dict[str, Any]:
             "actor": comment.get("actor") or "",
             "participant_role": participant_role(comment.get("actor_role") or ""),
             "body": comment.get("body") or "",
+            "positive_reactors": comment.get("positive_reactors") or [],
         }
         for comment in (thread.get("comments") or [])
     ]

--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -497,18 +497,6 @@ def positive_reaction_logins(comment: dict[str, Any]) -> set[str]:
     return logins
 
 
-def reviewer_acknowledged_latest_author_comment(comments: list[dict[str, Any]]) -> bool:
-    if not comments or comments[-1].get("actor_role") != "author":
-        return False
-    thread_reviewers = {
-        comment.get("actor", "").lower()
-        for comment in comments[:-1]
-        if comment.get("actor_role") in ("approver", "outsider") and comment.get("actor")
-    }
-    positive_reactors = {login.lower() for login in comments[-1].get("positive_reactors") or []}
-    return bool(thread_reviewers & positive_reactors)
-
-
 def group_review_threads(
     raw: dict[str, Any],
     author: str,
@@ -537,8 +525,6 @@ def group_review_threads(
         comments = [c for c in comments if c["timestamp"]]
         comments.sort(key=lambda c: c["timestamp"])
         if not comments:
-            continue
-        if reviewer_acknowledged_latest_author_comment(comments):
             continue
         threads.append(add_thread_facts({
             "thread_id": thread.get("id") or f"review-thread-{len(threads) + 1}",

--- a/.github/scripts/pull-request-dashboard/github_cli.py
+++ b/.github/scripts/pull-request-dashboard/github_cli.py
@@ -215,7 +215,11 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                             }
                             reactionGroups {
                                 content
-                                users(first: 100) {
+                                # Keep this capped at 20: this bulk query can
+                                # request 100 review threads * 100 comments *
+                                # 20 reaction users = 200,000 possible user
+                                # nodes, below GitHub's 500,000 GraphQL ceiling.
+                                users(first: 20) {
                                     nodes {
                                         login
                                     }
@@ -249,7 +253,9 @@ query($thread_id: ID!, $after: String) {
                     }
                     reactionGroups {
                         content
-                        users(first: 100) {
+                        # Keep this aligned with REVIEW_THREADS_QUERY so every
+                        # fetched comment has the same reaction-user cap.
+                        users(first: 20) {
                             nodes {
                                 login
                             }

--- a/.github/scripts/pull-request-dashboard/github_cli.py
+++ b/.github/scripts/pull-request-dashboard/github_cli.py
@@ -215,10 +215,10 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
                             }
                             reactionGroups {
                                 content
-                                # Keep this capped at 20: this bulk query can
-                                # request 100 review threads * 100 comments *
-                                # 20 reaction users = 200,000 possible user
-                                # nodes, below GitHub's 500,000 GraphQL ceiling.
+                                # Keep this cap intentionally low: this users
+                                # connection is nested under reactionGroups for
+                                # each fetched review comment, so raising it can
+                                # multiply the query's possible node count.
                                 users(first: 20) {
                                     nodes {
                                         login


### PR DESCRIPTION
Keep PR dashboard review reaction fetching under GitHub's GraphQL node ceiling by capping reaction users in the bulk review-thread query. Positive reactions are now included in the LLM classification input instead of pre-closing review threads, so acknowledgements can be interpreted together with the author's comment text.