### PR TITLE
Improve Slack PR notification links

### DIFF
--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -81,7 +81,7 @@ def post_slack_webhook(message: str, webhook_url: str) -> None:
         return
 
 
-def slack_escape_text(text: str) -> str:
+def slack_escape_link_text(text: str) -> str:
     return html.escape(text, quote=False)
 
 
@@ -89,7 +89,7 @@ def slack_message(repo: str, result: dict[str, Any], reviewer_mentions: str, kin
     facts = result.get("facts") or {}
     number = result.get("pr_number")
     url = result.get("pr_url") or f"https://github.com/{repo}/pull/{number}"
-    title = slack_escape_text(str(result.get("pr_title") or "").strip())
+    title = slack_escape_link_text(str(result.get("pr_title") or "").strip())
     pr_link_text = f"{title} (#{number})" if title else f"PR #{number}"
     if kind == "follow-up":
         waiting_age = activity_age(parse_ts(facts.get("waiting_since") or ""))

--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -82,6 +82,8 @@ def post_slack_webhook(message: str, webhook_url: str) -> None:
 
 
 def slack_escape_link_text(text: str) -> str:
+    # Slack link text requires escaping &, <, and >.
+    # Other PR title punctuation can be rendered as-is.
     return html.escape(text, quote=False)
 
 

--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import html
 import json
 import os
 import sys
@@ -80,16 +81,23 @@ def post_slack_webhook(message: str, webhook_url: str) -> None:
         return
 
 
+def slack_escape_text(text: str) -> str:
+    return html.escape(text, quote=False)
+
+
 def slack_message(repo: str, result: dict[str, Any], reviewer_mentions: str, kind: str) -> str:
     facts = result.get("facts") or {}
     number = result.get("pr_number")
     url = result.get("pr_url") or f"https://github.com/{repo}/pull/{number}"
+    title = slack_escape_text(str(result.get("pr_title") or "").strip())
+    pr_link_text = f"{title} (#{number})" if title else f"PR #{number}"
     if kind == "follow-up":
         waiting_age = activity_age(parse_ts(facts.get("waiting_since") or ""))
-        lead = f"is waiting on reviewers for {waiting_age}"
+        waiting_suffix = f" ({waiting_age})" if waiting_age != "?" else ""
+        lead = f"waiting on reviewers{waiting_suffix}"
     else:
         lead = "moved to waiting on reviewers"
-    return f"{reviewer_mentions} <{url}|PR #{number}> {lead}"
+    return f"{reviewer_mentions} - {lead}: <{url}|{pr_link_text}>"
 
 
 def pending_notification_kind(

--- a/.github/scripts/pull-request-dashboard/notify_slack.py
+++ b/.github/scripts/pull-request-dashboard/notify_slack.py
@@ -32,6 +32,9 @@ def notify_slack_from_state(
     open_pr_numbers = {p["number"] for p in prs if not p.get("isDraft")}
     dashboard_state = load_dashboard_state_cache()
     results = results_from_dashboard_state(dashboard_state, open_pr_numbers)
+    current_prs = {p["number"]: p for p in prs}
+    for number, result in results.items():
+        result["pr_title"] = current_prs.get(number, {}).get("title") or ""
 
     state_file_notification_state = load_notification_state_file()
     previous_state = state_file_notification_state


### PR DESCRIPTION
Update pull request dashboard Slack notifications to use title-first PR link text, e.g. `Add GenAI telemetry (#123)`, and adjust initial/follow-up wording so reviewer notifications read clearly in-channel.