### PR TITLE
Avoid reviewer badges from PR conversation

### DIFF
--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -736,6 +736,10 @@ def reviewers_with_open_threads(
     by_id = threads_by_id(threads)
     logins: set[str] = set()
     for c in classifications:
+        # The synthetic PR conversation is only for side-level routing, not
+        # for assigning per-reviewer open-thread badges.
+        if c.get("thread_kind") == "pr-conversation":
+            continue
         action = normalize_thread_action((c.get("decision") or {}).get("thread_action") or "")
         if action not in OPEN_THREAD_ACTIONS:
             continue

--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -736,8 +736,8 @@ def reviewers_with_open_threads(
     by_id = threads_by_id(threads)
     logins: set[str] = set()
     for c in classifications:
-        # The synthetic PR conversation is only for side-level routing, not
-        # for assigning per-reviewer open-thread badges.
+        # The synthetic PR conversation contributes to the PR's routing bucket,
+        # but it is not a reviewer-owned discussion thread for badges.
         if c.get("thread_kind") == "pr-conversation":
             continue
         action = normalize_thread_action((c.get("decision") or {}).get("thread_action") or "")


### PR DESCRIPTION
Prevent synthetic PR conversation threads from assigning person-level open-thread badges. The conversation thread still contributes to author/reviewer routing, while real review comment threads continue to mark participating reviewers.