### PR TITLE
Reduce Renovate PR frequency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,10 +44,14 @@
       "timezone": "America/Los_Angeles"
     },
     {
-      "groupName": "GitHub Actions",
-      "commitMessageTopic": "GitHub Actions",
+      "description": "Monthly tooling dependency updates",
+      "groupName": "tooling dependencies",
+      "commitMessageTopic": "tooling dependencies",
       "matchFileNames": [
-        ".github/**"
+        ".github/**",
+        "changelog.d/**",
+        "docs/gen-ai/non-normative/**",
+        "mise.toml"
       ],
       "schedule": [
         "* 0-3 2 * *" // 2nd of the month, 00:00–03:59 America/Los_Angeles


### PR DESCRIPTION
Group routine tooling dependency updates into the existing monthly Renovate window. This keeps GitHub Actions, changelog tooling, non-normative docs generator dependencies, and top-level mise tool pins on the monthly cadence while leaving versions.env pins outside the schedule so Weaver and semantic-conventions updates can arrive immediately.