### PR TITLE
Scope PR dashboard Slack notifications

### DIFF
--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -185,6 +185,7 @@ def next_notification_state(
     previous_state: dict[str, Any],
     now: datetime,
     notification_numbers: set[int] | None = None,
+    notification_kinds: set[str] | None = None,
 ) -> dict[str, Any]:
     previous_prs = previous_state.get("prs") or {}
     previous_state_exists = bool(previous_state.get("_loaded_from_dashboard"))
@@ -226,6 +227,8 @@ def next_notification_state(
         kind = pending_notification_kind(
             previous_state_exists, previous_pr_state, current_waiting_since, now,
         )
+        if kind and notification_kinds is not None and kind not in notification_kinds:
+            kind = None
 
         new_pr_state: dict[str, Any] = {
             "last_notified_at": previous_pr_state.get("last_notified_at") or "",

--- a/.github/scripts/pull-request-dashboard/notify_slack.py
+++ b/.github/scripts/pull-request-dashboard/notify_slack.py
@@ -27,6 +27,8 @@ from utils import utc_now
 def notify_slack_from_state(
     repo: str,
     prior_notification_state: Path | None,
+    notification_numbers: set[int] | None,
+    notification_kinds: set[str] | None,
 ) -> list[str]:
     prs = list_open_prs(repo)
     open_pr_numbers = {p["number"] for p in prs if not p.get("isDraft")}
@@ -47,6 +49,8 @@ def notify_slack_from_state(
         results,
         previous_state,
         utc_now(),
+        notification_numbers=notification_numbers,
+        notification_kinds=notification_kinds,
     )
     notification_errors = [str(error) for error in notification_state.get("_notification_errors") or []]
     notification_state_changed = (notification_state.get("prs") or {}) != (
@@ -68,9 +72,14 @@ def notification_errors_path() -> Path:
     return Path(os.environ.get("RUNNER_TEMP", ".")) / "notification-errors.txt"
 
 
-def notify_slack(prior_notification_state: Path, notification_errors: Path) -> int:
+def notify_slack(
+    prior_notification_state: Path,
+    notification_errors: Path,
+    notification_numbers: set[int] | None,
+    notification_kinds: set[str] | None,
+) -> int:
     repo = detect_repo()
-    errors = notify_slack_from_state(repo, prior_notification_state)
+    errors = notify_slack_from_state(repo, prior_notification_state, notification_numbers, notification_kinds)
     if errors:
         notification_errors.write_text("\n".join(errors) + "\n", encoding="utf-8")
     else:
@@ -82,10 +91,12 @@ def notify_slack_with_state(args: argparse.Namespace, state_dir: Path) -> int:
     prior_notification_state = prior_notification_state_path()
     notification_errors = notification_errors_path()
     notification_errors.unlink(missing_ok=True)
+    notification_numbers = {args.pr_number} if args.pr_number is not None else None
+    notification_kinds = {"initial"} if args.pr_number is not None else {"follow-up"}
     status = state_branch.push_state_changes(
         state_dir,
         "Update dashboard notification state",
-        lambda: notify_slack(prior_notification_state, notification_errors),
+        lambda: notify_slack(prior_notification_state, notification_errors, notification_numbers, notification_kinds),
         state_branch=args.state_branch,
         add_paths=["notification-state.json"],
         retry_snapshots=[(notification_state_path(), prior_notification_state)],
@@ -105,6 +116,11 @@ def main() -> int:
         "--state-branch",
         required=True,
         help="git branch used for workflow state",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help="send initial notifications for one pull request; omit for scheduled follow-up notifications",
     )
     args = parser.parse_args()
     with state_branch.temporary_state_dir() as state_dir:

--- a/.github/workflows/pull-request-dashboard.yml
+++ b/.github/workflows/pull-request-dashboard.yml
@@ -290,14 +290,18 @@ jobs:
           python3 .github/scripts/pull-request-dashboard/dashboard.py "${dashboard_args[@]}"
 
   notify-slack:
-    needs: update-dashboard
-    if: needs.update-dashboard.result == 'success'
-    # Slack sends are external side effects, so serialize notification
-    # processing while still allowing PR-specific dashboard computation to run
-    # concurrently. The notification ledger is pushed with the same state-branch
-    # CAS retry loop used by dashboard updates.
+    needs: [resolve-trigger, update-dashboard]
+    if: >-
+      needs.update-dashboard.result == 'success' &&
+      (needs.resolve-trigger.outputs.trigger_event == 'schedule' ||
+       needs.resolve-trigger.outputs.pr_number != '')
+    # Scheduled runs sweep only past-due follow-ups. Targeted runs notify only
+    # the triggering PR and suppress follow-ups, so the two paths do not send
+    # the same Slack side effect concurrently. The notification ledger is
+    # pushed with the same state-branch CAS retry loop used by dashboard
+    # updates.
     concurrency:
-      group: ${{ github.workflow }}-notify-${{ github.repository }}
+      group: ${{ github.workflow }}-notify-${{ github.repository }}-${{ needs.resolve-trigger.outputs.pr_number || 'hourly' }}
       cancel-in-progress: false
     permissions:
       contents: write
@@ -322,10 +326,15 @@ jobs:
           OTELBOT_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USER_MAP_JSON: ${{ vars.SLACK_USER_MAP_JSON }}
+          TRIGGER_PR_NUMBER: ${{ needs.resolve-trigger.outputs.pr_number }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/pull-request-dashboard/notify_slack.py \
-            --state-branch "$DASHBOARD_STATE_BRANCH"
+          notify_args=(--state-branch "$DASHBOARD_STATE_BRANCH")
+          if [[ -n "${TRIGGER_PR_NUMBER:-}" ]]; then
+            notify_args+=(--pr-number "$TRIGGER_PR_NUMBER")
+          fi
+
+          python3 .github/scripts/pull-request-dashboard/notify_slack.py "${notify_args[@]}"
 
   publish-dashboard:
     needs: update-dashboard


### PR DESCRIPTION
Scope PR dashboard Slack notification processing so targeted refreshes only send initial notifications for the triggering PR, while scheduled runs handle follow-up reminders across open PRs. This keeps per-PR notification concurrency from duplicating Slack side effects while preserving the hourly past-due reminder sweep.