### PR TITLE
Add GenAI client metrics to the anthropic reference scenario

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -41,4 +41,11 @@ Run `uv run update-reports` to regenerate.
 | --- | --- |
 | [Inference Operation Details](reports/gen-ai-client-inference-operation-details-event.md) | anthropic, autogen, aws-bedrock, azure-ai-inference, cohere, dspy, google-genai, groq, instructor, litellm, llamaindex, mistralai, openai, pydantic-ai, vertexai |
 | [Evaluation Result](reports/gen-ai-evaluation-result-event.md) | azure-ai-evaluation, deepeval, dspy |
+
+### Metrics
+
+| Metric | Libraries |
+| --- | --- |
+| [Client Token Usage](reports/gen-ai-client-token-usage-metric.md) | anthropic |
+| [Client Operation Duration](reports/gen-ai-client-operation-duration-metric.md) | anthropic |
 <!-- status:end -->

--- a/reference/reports/gen-ai-client-operation-duration-metric.md
+++ b/reference/reports/gen-ai-client-operation-duration-metric.md
@@ -12,6 +12,7 @@
 
 | Attribute | Supporting Libraries |
 | --- | --- |
+| error.type | [anthropic] |
 | gen_ai.provider.name | [anthropic] |
 | gen_ai.request.model | [anthropic] |
 | server.port | [anthropic] |

--- a/reference/reports/gen-ai-client-operation-duration-metric.md
+++ b/reference/reports/gen-ai-client-operation-duration-metric.md
@@ -1,0 +1,26 @@
+# Client Operation Duration Metric
+
+> **[Semantic Convention](../../docs/gen-ai/gen-ai-metrics.md#metric-gen_aiclientoperationduration)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [anthropic] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.provider.name | [anthropic] |
+| gen_ai.request.model | [anthropic] |
+| server.port | [anthropic] |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.response.model | [anthropic] |
+| server.address | [anthropic] |
+
+[anthropic]: ../scenarios/anthropic/scenario.py

--- a/reference/reports/gen-ai-client-token-usage-metric.md
+++ b/reference/reports/gen-ai-client-token-usage-metric.md
@@ -1,0 +1,27 @@
+# Client Token Usage Metric
+
+> **[Semantic Convention](../../docs/gen-ai/gen-ai-metrics.md#metric-gen_aiclienttokenusage)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [anthropic] |
+| gen_ai.provider.name | [anthropic] |
+| gen_ai.token.type | [anthropic] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.request.model | [anthropic] |
+| server.port | [anthropic] |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.response.model | [anthropic] |
+| server.address | [anthropic] |
+
+[anthropic]: ../scenarios/anthropic/scenario.py

--- a/reference/scenarios/anthropic/data.json
+++ b/reference/scenarios/anthropic/data.json
@@ -34,5 +34,24 @@
       "server.address",
       "server.port"
     ]
+  },
+  "metrics": {
+    "gen_ai.client.token.usage": [
+      "gen_ai.operation.name",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.model",
+      "gen_ai.token.type",
+      "server.address",
+      "server.port"
+    ],
+    "gen_ai.client.operation.duration": [
+      "gen_ai.operation.name",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.model",
+      "server.address",
+      "server.port"
+    ]
   }
 }

--- a/reference/scenarios/anthropic/data.json
+++ b/reference/scenarios/anthropic/data.json
@@ -46,6 +46,7 @@
       "server.port"
     ],
     "gen_ai.client.operation.duration": [
+      "error.type",
       "gen_ai.operation.name",
       "gen_ai.provider.name",
       "gen_ai.request.model",

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -71,8 +71,11 @@ def run_chat():
         if port is not None:
             metric_attributes["server.port"] = port
         if resp.usage:
+            cache_creation = getattr(resp.usage, "cache_creation_input_tokens", None) or 0
+            cache_read = getattr(resp.usage, "cache_read_input_tokens", None) or 0
+            total_input = resp.usage.input_tokens + cache_creation + cache_read
             token_usage_histogram.record(
-                resp.usage.input_tokens,
+                total_input,
                 attributes={**metric_attributes, "gen_ai.token.type": "input"},
             )
             token_usage_histogram.record(

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -18,7 +18,7 @@ from reference_shared import (
 )
 
 MOCK_BASE_URL = os.environ["MOCK_LLM_URL"]
-TOKEN_BUCKET_BOUNDARIES = [1, 4, 16, 64, 256, 1024, 4096]
+TOKEN_BUCKET_BOUNDARIES = [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864]
 
 _reference_tracer = reference_tracer()
 _reference_meter = reference_meter()

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -244,6 +244,42 @@ def run_chat_with_document_input():
         print(f"    -> {resp.content[0].text[:60]}")
 
 
+def run_chat_error():
+    """Scenario: error path — records operation duration with error.type.
+
+    Connects to an unreachable address so the Anthropic SDK raises
+    APIConnectionError, exercising the error.type attribute on the
+    gen_ai.client.operation.duration metric.
+    """
+    import anthropic
+
+    print("  [chat_error] error path (reference implementation)")
+    request_model = "claude-sonnet-4-20250514"
+    # Point to a port that is not listening so the SDK raises APIConnectionError.
+    bad_url = "http://127.0.0.1:1"
+    client = anthropic.Anthropic(base_url=bad_url, api_key="mock-key")
+
+    metric_attributes = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "anthropic",
+        "gen_ai.request.model": request_model,
+    }
+    start_time = time.perf_counter()
+    try:
+        client.messages.create(
+            model=request_model,
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Say hello."}],
+        )
+    except anthropic.APIError as exc:
+        elapsed = time.perf_counter() - start_time
+        _operation_duration_histogram.record(
+            elapsed,
+            attributes={**metric_attributes, "error.type": type(exc).__qualname__},
+        )
+        print(f"    -> error recorded: {type(exc).__qualname__}")
+
+
 def main():
     print("=== Reference Implementation: Anthropic Reference Implementation ===")
 
@@ -251,6 +287,7 @@ def main():
 
     run_chat()
     run_chat_with_document_input()
+    run_chat_error()
 
     flush_and_shutdown(tp, lp, mp)
 

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -6,11 +6,13 @@ against a mock Anthropic server, with manual OTel spans.
 
 import json
 import os
+import time
 
 from reference_shared import (
     flush_and_shutdown,
     mock_server_host_port,
     reference_event_logger,
+    reference_meter,
     reference_tracer,
     setup_otel,
 )
@@ -29,6 +31,9 @@ def run_chat():
     request_max_tokens = 100
     messages = [{"role": "user", "content": "Say hello."}]
     client = anthropic.Anthropic(base_url=MOCK_BASE_URL, api_key="mock-key")
+    meter = reference_meter()
+    token_usage_histogram = meter.create_histogram("gen_ai.client.token.usage", unit="{token}")
+    operation_duration_histogram = meter.create_histogram("gen_ai.client.operation.duration", unit="s")
 
     host, port = mock_server_host_port(MOCK_BASE_URL)
     span_attributes = {
@@ -46,11 +51,35 @@ def run_chat():
             "gen_ai.input.messages",
             json.dumps([{"role": m["role"], "parts": [{"type": "text", "content": m["content"]}]} for m in messages]),
         )
+        start_time = time.perf_counter()
         resp = client.messages.create(
             model=request_model,
             max_tokens=request_max_tokens,
             messages=messages,
         )
+        elapsed = time.perf_counter() - start_time
+        metric_attributes = {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.provider.name": "anthropic",
+            "gen_ai.request.model": request_model,
+        }
+        response_model = getattr(resp, "model", None)
+        if response_model:
+            metric_attributes["gen_ai.response.model"] = response_model
+        if host:
+            metric_attributes["server.address"] = host
+        if port is not None:
+            metric_attributes["server.port"] = port
+        if resp.usage:
+            token_usage_histogram.record(
+                resp.usage.input_tokens,
+                attributes={**metric_attributes, "gen_ai.token.type": "input"},
+            )
+            token_usage_histogram.record(
+                resp.usage.output_tokens,
+                attributes={**metric_attributes, "gen_ai.token.type": "output"},
+            )
+        operation_duration_histogram.record(elapsed, attributes=metric_attributes)
         span.set_attribute("gen_ai.response.model", resp.model)
         span.set_attribute("gen_ai.response.id", resp.id)
         span.set_attribute("gen_ai.response.finish_reasons", [resp.stop_reason])

--- a/reference/scenarios/anthropic/scenario.py
+++ b/reference/scenarios/anthropic/scenario.py
@@ -18,8 +18,16 @@ from reference_shared import (
 )
 
 MOCK_BASE_URL = os.environ["MOCK_LLM_URL"]
+TOKEN_BUCKET_BOUNDARIES = [1, 4, 16, 64, 256, 1024, 4096]
 
 _reference_tracer = reference_tracer()
+_reference_meter = reference_meter()
+_token_usage_histogram = _reference_meter.create_histogram(
+    "gen_ai.client.token.usage",
+    unit="{token}",
+    explicit_bucket_boundaries_advisory=TOKEN_BUCKET_BOUNDARIES,
+)
+_operation_duration_histogram = _reference_meter.create_histogram("gen_ai.client.operation.duration", unit="s")
 
 
 def run_chat():
@@ -31,9 +39,6 @@ def run_chat():
     request_max_tokens = 100
     messages = [{"role": "user", "content": "Say hello."}]
     client = anthropic.Anthropic(base_url=MOCK_BASE_URL, api_key="mock-key")
-    meter = reference_meter()
-    token_usage_histogram = meter.create_histogram("gen_ai.client.token.usage", unit="{token}")
-    operation_duration_histogram = meter.create_histogram("gen_ai.client.operation.duration", unit="s")
 
     host, port = mock_server_host_port(MOCK_BASE_URL)
     span_attributes = {
@@ -74,15 +79,15 @@ def run_chat():
             cache_creation = getattr(resp.usage, "cache_creation_input_tokens", None) or 0
             cache_read = getattr(resp.usage, "cache_read_input_tokens", None) or 0
             total_input = resp.usage.input_tokens + cache_creation + cache_read
-            token_usage_histogram.record(
+            _token_usage_histogram.record(
                 total_input,
                 attributes={**metric_attributes, "gen_ai.token.type": "input"},
             )
-            token_usage_histogram.record(
+            _token_usage_histogram.record(
                 resp.usage.output_tokens,
                 attributes={**metric_attributes, "gen_ai.token.type": "output"},
             )
-        operation_duration_histogram.record(elapsed, attributes=metric_attributes)
+        _operation_duration_histogram.record(elapsed, attributes=metric_attributes)
         span.set_attribute("gen_ai.response.model", resp.model)
         span.set_attribute("gen_ai.response.id", resp.id)
         span.set_attribute("gen_ai.response.finish_reasons", [resp.stop_reason])

--- a/reference/shared/reference_shared.py
+++ b/reference/shared/reference_shared.py
@@ -28,6 +28,11 @@ def reference_tracer(name: str = GENAI_REFERENCE_INSTRUMENTATION) -> trace.Trace
     return trace.get_tracer(name)
 
 
+def reference_meter(name: str = GENAI_REFERENCE_INSTRUMENTATION) -> metrics.Meter:
+    """Return the meter used by reference scenarios to emit gen_ai.* metrics."""
+    return metrics.get_meter(name)
+
+
 def reference_event_logger(name: str = GENAI_REFERENCE_INSTRUMENTATION):
     """Return the Logger used by reference scenarios to emit gen_ai.* events."""
     return get_logger_provider().get_logger(name)

--- a/reference/src/semconv_genai/classify.py
+++ b/reference/src/semconv_genai/classify.py
@@ -1,8 +1,8 @@
-"""GenAI span classification: map span attributes to declared span types."""
+"""GenAI signal classification: map observed telemetry to declared GenAI types."""
 
 from __future__ import annotations
 
-from .semconv_model import SPAN_SPECS
+from .semconv_model import METRIC_SPECS, SPAN_SPECS
 
 
 def _has_any_attr(attrs: dict[str, object], *names: str) -> bool:
@@ -40,3 +40,9 @@ def classify_span(span_name: str, span_kind: str, span_attrs: dict[str, object])
         detected.discard("invoke_agent_client" if not is_remote else "invoke_agent_internal")
 
     return detected
+
+
+def classify_metric(metric_name: str, metric_attrs: dict[str, object]) -> set[str]:
+    """Classify a metric data point into GenAI metric types."""
+    del metric_attrs  # Metric identity is represented by the metric name.
+    return {metric_name} if metric_name in METRIC_SPECS else set()

--- a/reference/src/semconv_genai/data_files.py
+++ b/reference/src/semconv_genai/data_files.py
@@ -184,10 +184,9 @@ def _metric_type_present_attributes(
     level: RequirementLevel,
 ) -> set[str]:
     """Return attrs present for a metric type at the requested requirement level."""
-    all_present = _present_attributes(result)
     if level is RequirementLevel.REQUIRED:
-        return result.detected.metric_attrs.get(metric_name, all_present)
-    return result.detected.metric_any_attrs.get(metric_name, all_present)
+        return result.detected.metric_attrs.get(metric_name, set())
+    return result.detected.metric_any_attrs.get(metric_name, set())
 
 
 def _build_metric_type_present_names(result: ScenarioResult) -> dict[str, list[str]]:

--- a/reference/src/semconv_genai/data_files.py
+++ b/reference/src/semconv_genai/data_files.py
@@ -54,10 +54,7 @@ EVENT_TYPE_ORDER = [
 ]
 
 # Display order for metric types in reports.
-METRIC_TYPE_ORDER = [
-    "gen_ai.client.token.usage",
-    "gen_ai.client.operation.duration",
-]
+METRIC_TYPE_ORDER = tuple(METRIC_SPECS)
 
 _REQUIREMENT_LEVELS = (
     RequirementLevel.REQUIRED,

--- a/reference/src/semconv_genai/data_files.py
+++ b/reference/src/semconv_genai/data_files.py
@@ -19,7 +19,7 @@ from semconv_genai import (
     reference_results_dir,
 )
 from semconv_genai.attribute_spec import AttributeSpec, RequirementLevel
-from semconv_genai.classify import classify_span
+from semconv_genai.classify import classify_metric, classify_span
 from semconv_genai.parse_results import (
     ScenarioResult,
     merge_signal_counts,
@@ -27,6 +27,7 @@ from semconv_genai.parse_results import (
 )
 from semconv_genai.semconv_model import (
     EVENT_SPECS,
+    METRIC_SPECS,
     SPAN_SPECS,
 )
 
@@ -50,6 +51,12 @@ SPAN_TYPE_ORDER = [
 EVENT_TYPE_ORDER = [
     "gen_ai.client.inference.operation.details",
     "gen_ai.evaluation.result",
+]
+
+# Display order for metric types in reports.
+METRIC_TYPE_ORDER = [
+    "gen_ai.client.token.usage",
+    "gen_ai.client.operation.duration",
 ]
 
 _REQUIREMENT_LEVELS = (
@@ -171,6 +178,28 @@ def _build_event_type_present_names(result: ScenarioResult) -> dict[str, list[st
     )
 
 
+def _metric_type_present_attributes(
+    result: ScenarioResult,
+    metric_name: str,
+    level: RequirementLevel,
+) -> set[str]:
+    """Return attrs present for a metric type at the requested requirement level."""
+    all_present = _present_attributes(result)
+    if level is RequirementLevel.REQUIRED:
+        return result.detected.metric_attrs.get(metric_name, all_present)
+    return result.detected.metric_any_attrs.get(metric_name, all_present)
+
+
+def _build_metric_type_present_names(result: ScenarioResult) -> dict[str, list[str]]:
+    """Return sparse per-metric-type attribute lists for detected metrics."""
+    merged = merge_signal_counts(result.observed.metrics, result.detected.metrics)
+    return _build_signal_type_present_names(
+        METRIC_SPECS,
+        merged,
+        lambda name, level: _metric_type_present_attributes(result, name, level),
+    )
+
+
 # ── Scenario data types and generation ──────────────────────────────
 
 
@@ -179,6 +208,7 @@ class ScenarioDataEntry:
     library: str
     spans: dict[str, dict[str, str]]
     events: dict[str, dict[str, str]]
+    metrics: dict[str, dict[str, str]]
 
 
 def _normalize_generated_scenario_payload(data: dict[str, object]) -> dict[str, object]:
@@ -194,25 +224,31 @@ def _normalize_generated_scenario_payload(data: dict[str, object]) -> dict[str, 
         normalized["events"] = {
             name: sorted(attrs) if isinstance(attrs, (list, set)) else [] for name, attrs in events.items()
         }
+    metrics = data.get("metrics")
+    if isinstance(metrics, dict) and metrics:
+        normalized["metrics"] = {
+            name: sorted(attrs) if isinstance(attrs, (list, set)) else [] for name, attrs in metrics.items()
+        }
     return normalized
 
 
 def _build_single_scenario_data(result: ScenarioResult) -> tuple[dict[str, object], bool]:
     """Build committed status-report data from a parsed Weaver result."""
     event_present = _build_event_type_present_names(result)
+    metric_present = _build_metric_type_present_names(result)
     spans = _build_span_type_present_names(result)
 
-    data: dict[str, object] = {"events": event_present}
+    data: dict[str, object] = {"events": event_present, "metrics": metric_present}
     if spans:
         data["spans"] = spans
 
-    return _normalize_generated_scenario_payload(data), bool(spans) or bool(event_present)
+    return _normalize_generated_scenario_payload(data), bool(spans) or bool(event_present) or bool(metric_present)
 
 
 def write_generated_scenario_data(library: str) -> Path:
     """Write committed status-report data for one library and return the data.json path."""
     result_dir = reference_results_dir(library)
-    result = parse_result_dir(result_dir, library, classify_span)
+    result = parse_result_dir(result_dir, library, classify_span, classify_metric)
     if result is None:
         raise ValueError(f"Could not parse Weaver results for library: {library}")
 
@@ -255,6 +291,7 @@ def _normalize_scenario_data_entry(entry: dict[str, object], library: str) -> Sc
         library=library,
         spans=_normalize_attr_data(entry.get("spans"), SPAN_SPECS),
         events=_normalize_attr_data(entry.get("events"), EVENT_SPECS),
+        metrics=_normalize_attr_data(entry.get("metrics"), METRIC_SPECS),
     )
 
 

--- a/reference/src/semconv_genai/parse_results.py
+++ b/reference/src/semconv_genai/parse_results.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .classify import classify_metric as _default_classify_metric
+
+_LOGGER = logging.getLogger(__name__)
 
 # ── Span classification types ──────────────────────────────────────
 
@@ -73,16 +76,37 @@ def _attribute_names(
     return names
 
 
-def _metric_data_points(metric: dict[str, object]) -> list[dict[str, object]]:
+def _metric_data_points(metric: dict[str, object]) -> list[dict[str, object]] | None:
     """Return metric data points from either known Weaver metric shapes."""
-    raw_points = metric.get("data_points")
-    if not isinstance(raw_points, list):
-        raw_data = metric.get("data")
+    marker = object()
+    raw_points = metric.get("data_points", marker)
+    if raw_points is marker:
+        raw_data = metric.get("data", marker)
         if isinstance(raw_data, dict):
-            raw_points = raw_data.get("data_points")
-    if not isinstance(raw_points, list):
-        return []
-    return [dp for dp in raw_points if isinstance(dp, dict)]
+            raw_points = raw_data.get("data_points", marker)
+    if raw_points is marker:
+        return [metric]
+    if isinstance(raw_points, dict):
+        return [raw_points]
+    if isinstance(raw_points, list):
+        data_points: list[dict[str, object]] = []
+        for data_point in raw_points:
+            if isinstance(data_point, dict):
+                data_points.append(data_point)
+                continue
+            _LOGGER.warning(
+                "Skipping non-dict data point for metric %r: %r",
+                metric.get("name", ""),
+                data_point,
+            )
+        return data_points
+
+    _LOGGER.warning(
+        "Skipping metric %r with invalid data_points: expected dict or list, got %s",
+        metric.get("name", ""),
+        type(raw_points).__name__,
+    )
+    return None
 
 
 def _summarize_samples(
@@ -130,21 +154,41 @@ def _summarize_samples(
             metric = sample.get("metric")
             if metric:
                 metric_name = metric.get("name", "")
-                if isinstance(metric_name, str) and metric_name:
-                    data_points = _metric_data_points(metric)
-                    observations = data_points if data_points else [metric]
-                    for observation in observations:
-                        metric_attrs = _attributes_by_name(observation, include_attr)
-                        attr_names = set(metric_attrs)
-                        for metric_type in classify_metric(metric_name, metric_attrs):
-                            if not metric_type.startswith("gen_ai."):
-                                continue
-                            signals.metrics[metric_type] = signals.metrics.get(metric_type, 0) + 1
-                            if metric_type not in signals.metric_attrs:
-                                signals.metric_attrs[metric_type] = set(attr_names)
-                            else:
-                                signals.metric_attrs[metric_type].intersection_update(attr_names)
-                            signals.metric_any_attrs.setdefault(metric_type, set()).update(attr_names)
+                if not isinstance(metric_name, str) or not metric_name:
+                    _LOGGER.warning("Skipping metric with invalid name: %r", metric_name)
+                    continue
+
+                observations = _metric_data_points(metric)
+                if observations is None or not observations:
+                    continue
+
+                metric_attrs_by_type: dict[str, set[str]] = {}
+                metric_any_attrs_by_type: dict[str, set[str]] = {}
+                for observation in observations:
+                    metric_attrs = _attributes_by_name(observation, include_attr)
+                    attr_names = set(metric_attrs)
+                    for metric_type in classify_metric(metric_name, metric_attrs):
+                        if not metric_type.startswith("gen_ai."):
+                            continue
+                        if metric_type not in metric_attrs_by_type:
+                            metric_attrs_by_type[metric_type] = set(attr_names)
+                        else:
+                            metric_attrs_by_type[metric_type].intersection_update(attr_names)
+                        metric_any_attrs_by_type.setdefault(metric_type, set()).update(attr_names)
+
+                if not metric_attrs_by_type:
+                    _LOGGER.warning("Skipping unrecognized metric: %s", metric_name)
+                    continue
+
+                for metric_type, attr_names in metric_attrs_by_type.items():
+                    signals.metrics[metric_type] = signals.metrics.get(metric_type, 0) + 1
+                    if metric_type not in signals.metric_attrs:
+                        signals.metric_attrs[metric_type] = set(attr_names)
+                    else:
+                        signals.metric_attrs[metric_type].intersection_update(attr_names)
+                    signals.metric_any_attrs.setdefault(metric_type, set()).update(
+                        metric_any_attrs_by_type.get(metric_type, set())
+                    )
 
     return spans, signals
 

--- a/reference/src/semconv_genai/parse_results.py
+++ b/reference/src/semconv_genai/parse_results.py
@@ -28,6 +28,7 @@ class DetectedSignals:
 
 
 ClassifySpan = Callable[[str, str, dict[str, object]], set[str]]
+ClassifyMetric = Callable[[str, dict[str, object]], set[str]]
 
 
 def _attributes_by_name(
@@ -67,35 +68,27 @@ def _attribute_names(
     return names
 
 
-def _metric_attribute_names(
-    metric: dict[str, object],
-    include_attr: Callable[[dict[str, object]], bool] | None = None,
-) -> set[str]:
-    names: set[str] = set()
-    raw_points = metric.get("data_points", [])
+def _metric_data_points(metric: dict[str, object]) -> list[dict[str, object]]:
+    """Return metric data points from either known Weaver metric shapes."""
+    raw_points = metric.get("data_points")
     if not isinstance(raw_points, list):
-        return names
-    for dp in raw_points:
-        if not isinstance(dp, dict):
-            continue
-        raw_attrs = dp.get("attributes", [])
-        if not isinstance(raw_attrs, list):
-            continue
-        for attr in raw_attrs:
-            if not isinstance(attr, dict):
-                continue
-            name = attr.get("name")
-            if not isinstance(name, str) or not name:
-                continue
-            if include_attr is not None and not include_attr(attr):
-                continue
-            names.add(name)
-    return names
+        raw_data = metric.get("data")
+        if isinstance(raw_data, dict):
+            raw_points = raw_data.get("data_points")
+    if not isinstance(raw_points, list):
+        return []
+    return [dp for dp in raw_points if isinstance(dp, dict)]
+
+
+def _classify_genai_metric(metric_name: str, metric_attrs: dict[str, object]) -> set[str]:
+    del metric_attrs
+    return {metric_name} if metric_name.startswith("gen_ai.") else set()
 
 
 def _summarize_samples(
     all_objects: list[dict],
     classify_span: ClassifySpan,
+    classify_metric: ClassifyMetric,
     include_attr: Callable[[dict[str, object]], bool] | None = None,
 ) -> tuple[SpanClassification, DetectedSignals]:
     """Scan sample payloads once and collect detected spans, events, and metrics."""
@@ -137,14 +130,21 @@ def _summarize_samples(
             metric = sample.get("metric")
             if metric:
                 metric_name = metric.get("name", "")
-                if metric_name.startswith("gen_ai."):
-                    signals.metrics[metric_name] = signals.metrics.get(metric_name, 0) + 1
-                    attr_names = _metric_attribute_names(metric, include_attr)
-                    if metric_name not in signals.metric_attrs:
-                        signals.metric_attrs[metric_name] = set(attr_names)
-                    else:
-                        signals.metric_attrs[metric_name].intersection_update(attr_names)
-                    signals.metric_any_attrs.setdefault(metric_name, set()).update(attr_names)
+                if isinstance(metric_name, str) and metric_name:
+                    data_points = _metric_data_points(metric)
+                    observations = data_points if data_points else [metric]
+                    for observation in observations:
+                        metric_attrs = _attributes_by_name(observation, include_attr)
+                        attr_names = set(metric_attrs)
+                        for metric_type in classify_metric(metric_name, metric_attrs):
+                            if not metric_type.startswith("gen_ai."):
+                                continue
+                            signals.metrics[metric_type] = signals.metrics.get(metric_type, 0) + 1
+                            if metric_type not in signals.metric_attrs:
+                                signals.metric_attrs[metric_type] = set(attr_names)
+                            else:
+                                signals.metric_attrs[metric_type].intersection_update(attr_names)
+                            signals.metric_any_attrs.setdefault(metric_type, set()).update(attr_names)
 
     return spans, signals
 
@@ -353,11 +353,13 @@ def _detected_signals_from_samples(
     all_objects: list[dict],
     statistics: dict | None,
     classify_span: ClassifySpan,
+    classify_metric: ClassifyMetric,
 ) -> tuple[SpanClassification, DetectedSignals]:
     """Classify spans and supplement detected signal counts from statistics."""
     span_classification, detected = _summarize_samples(
         all_objects,
         classify_span,
+        classify_metric,
         include_attr=_attribute_counts_as_present,
     )
     stats = statistics or {}
@@ -380,6 +382,7 @@ def parse_result_dir(
     result_dir: Path,
     library: str,
     classify_span: ClassifySpan,
+    classify_metric: ClassifyMetric = _classify_genai_metric,
 ) -> ScenarioResult | None:
     """Parse a single library's Weaver output directory into a ScenarioResult."""
     if not result_dir.is_dir():
@@ -388,7 +391,9 @@ def parse_result_dir(
     all_objects = _load_result_objects(result_dir)
     statistics = _extract_statistics(all_objects)
     observed = _observed_telemetry_from_statistics(statistics, all_objects)
-    span_classification, detected = _detected_signals_from_samples(all_objects, statistics, classify_span)
+    span_classification, detected = _detected_signals_from_samples(
+        all_objects, statistics, classify_span, classify_metric
+    )
     return ScenarioResult(
         library=library,
         statistics=statistics,

--- a/reference/src/semconv_genai/parse_results.py
+++ b/reference/src/semconv_genai/parse_results.py
@@ -7,6 +7,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .classify import classify_metric as _default_classify_metric
+
 # ── Span classification types ──────────────────────────────────────
 
 
@@ -42,9 +44,12 @@ def _attributes_by_name(
     for attr in raw_attrs:
         if not isinstance(attr, dict):
             continue
+        name = attr.get("name")
+        if not isinstance(name, str) or not name:
+            continue
         if include_attr is not None and not include_attr(attr):
             continue
-        attrs[attr.get("name", "")] = attr.get("value")
+        attrs[name] = attr.get("value")
     return attrs
 
 
@@ -78,11 +83,6 @@ def _metric_data_points(metric: dict[str, object]) -> list[dict[str, object]]:
     if not isinstance(raw_points, list):
         return []
     return [dp for dp in raw_points if isinstance(dp, dict)]
-
-
-def _classify_genai_metric(metric_name: str, metric_attrs: dict[str, object]) -> set[str]:
-    del metric_attrs
-    return {metric_name} if metric_name.startswith("gen_ai.") else set()
 
 
 def _summarize_samples(
@@ -382,7 +382,7 @@ def parse_result_dir(
     result_dir: Path,
     library: str,
     classify_span: ClassifySpan,
-    classify_metric: ClassifyMetric = _classify_genai_metric,
+    classify_metric: ClassifyMetric = _default_classify_metric,
 ) -> ScenarioResult | None:
     """Parse a single library's Weaver output directory into a ScenarioResult."""
     if not result_dir.is_dir():

--- a/reference/src/semconv_genai/pipeline.py
+++ b/reference/src/semconv_genai/pipeline.py
@@ -35,7 +35,7 @@ from semconv_genai import (
     SEMCONV_ROOT,
     reference_results_dir,
 )
-from semconv_genai.classify import classify_span
+from semconv_genai.classify import classify_metric, classify_span
 from semconv_genai.data_files import write_generated_scenario_data
 from semconv_genai.parse_results import parse_result_dir
 from semconv_genai.uv_env import (
@@ -277,7 +277,7 @@ def run_one_library(
         weaver_proc = None
         logger.info("Weaver exit code: %s", weaver_exit)
         logger.info("Results in: %s", scenario_results_dir)
-        fresh_result = parse_result_dir(scenario_results_dir, library, classify_span)
+        fresh_result = parse_result_dir(scenario_results_dir, library, classify_span, classify_metric)
         if exit_code != 0:
             raise RunScenarioError(
                 f"Scenario exited with code {exit_code}.",

--- a/reference/src/semconv_genai/report.py
+++ b/reference/src/semconv_genai/report.py
@@ -152,7 +152,7 @@ def _render_signal_section(
 
     used_libraries: set[str] = set()
     for level in LEVEL_ORDER:
-        attr_names = [a for a in spec.attrs_for_requirement_level(level) if a not in DISPLAY_HIDDEN_ATTRS]
+        attr_names = [a for a in spec.attrs_for_requirement_level(level) if a not in DISPLAY_HIDDEN_ATTRS or _supporting_libraries(entries, type_key, a, by_signal)]
         if not attr_names:
             continue
 

--- a/reference/src/semconv_genai/report.py
+++ b/reference/src/semconv_genai/report.py
@@ -24,12 +24,14 @@ from semconv_genai import (
 from semconv_genai.attribute_spec import AttributeSpec, RequirementLevel
 from semconv_genai.data_files import (
     EVENT_TYPE_ORDER,
+    METRIC_TYPE_ORDER,
     SPAN_TYPE_ORDER,
     ScenarioDataEntry,
     load_scenario_data_files,
 )
 from semconv_genai.semconv_model import (
     EVENT_SPECS,
+    METRIC_SPECS,
     SPAN_SPECS,
 )
 
@@ -65,6 +67,10 @@ def _events_of(entry: ScenarioDataEntry) -> dict[str, dict[str, str]]:
     return entry.events
 
 
+def _metrics_of(entry: ScenarioDataEntry) -> dict[str, dict[str, str]]:
+    return entry.metrics
+
+
 # Relative paths from reports/ to the semantic convention doc page + anchor.
 SEMCONV_DOC_LINKS: dict[str, str] = {
     "create_agent": "../../docs/gen-ai/gen-ai-agent-spans.md#create-agent-span",
@@ -79,6 +85,8 @@ SEMCONV_DOC_LINKS: dict[str, str] = {
     "execute_tool": "../../docs/gen-ai/gen-ai-spans.md#execute-tool-span",
     "gen_ai.client.inference.operation.details": "../../docs/gen-ai/gen-ai-events.md#event-gen_aiclientinferenceoperationdetails",
     "gen_ai.evaluation.result": "../../docs/gen-ai/gen-ai-events.md#event-gen_aievaluationresult",
+    "gen_ai.client.token.usage": "../../docs/gen-ai/gen-ai-metrics.md#metric-gen_aiclienttokenusage",
+    "gen_ai.client.operation.duration": "../../docs/gen-ai/gen-ai-metrics.md#metric-gen_aiclientoperationduration",
 }
 
 
@@ -241,6 +249,22 @@ def generate_index_markdown(
         supporting = _get_supporting_entries(entries, event_type, spec, _events_of)
         lines.append(f"| [{spec.label}](reports/{filename}) | {_library_dir_links(supporting)} |")
 
+    lines.extend(
+        [
+            "",
+            "### Metrics",
+            "",
+            "| Metric | Libraries |",
+            "| --- | --- |",
+        ]
+    )
+
+    for metric_type in METRIC_TYPE_ORDER:
+        spec = METRIC_SPECS[metric_type]
+        filename = _report_filename(metric_type, "metric")
+        supporting = _get_supporting_entries(entries, metric_type, spec, _metrics_of)
+        lines.append(f"| [{spec.label}](reports/{filename}) | {_library_dir_links(supporting)} |")
+
     lines.append("")
     return "\n".join(lines)
 
@@ -268,6 +292,16 @@ def write_report_pages(output_dir: Path) -> None:
 
         page_path = reports_dir / _report_filename(event_type, "event")
         page_lines = _render_signal_section(entries, event_type, spec, reports_dir, "Event", _events_of)
+        page_path.write_text(_generate_detail_page(page_lines), encoding="utf-8")
+
+    for metric_type in METRIC_TYPE_ORDER:
+        spec = METRIC_SPECS[metric_type]
+        legacy_page_path = reports_dir / f"{_type_slug(metric_type)}.md"
+        if legacy_page_path.exists():
+            legacy_page_path.unlink()
+
+        page_path = reports_dir / _report_filename(metric_type, "metric")
+        page_lines = _render_signal_section(entries, metric_type, spec, reports_dir, "Metric", _metrics_of)
         page_path.write_text(_generate_detail_page(page_lines), encoding="utf-8")
 
 

--- a/reference/src/semconv_genai/report.py
+++ b/reference/src/semconv_genai/report.py
@@ -152,7 +152,11 @@ def _render_signal_section(
 
     used_libraries: set[str] = set()
     for level in LEVEL_ORDER:
-        attr_names = [a for a in spec.attrs_for_requirement_level(level) if a not in DISPLAY_HIDDEN_ATTRS or _supporting_libraries(entries, type_key, a, by_signal)]
+        attr_names = [
+            a
+            for a in spec.attrs_for_requirement_level(level)
+            if a not in DISPLAY_HIDDEN_ATTRS or _supporting_libraries(entries, type_key, a, by_signal)
+        ]
         if not attr_names:
             continue
 

--- a/reference/src/semconv_genai/semconv_model.py
+++ b/reference/src/semconv_genai/semconv_model.py
@@ -24,12 +24,12 @@ _MODEL_DIR = MODEL_ROOT / "gen-ai"
 
 def _load_groups() -> dict[str, dict]:
     """Load all source files under ``model/gen-ai/`` and return a unified
-    lookup keyed by a synthetic id covering attribute groups, spans, and
-    events.
+    lookup keyed by a synthetic id covering attribute groups, spans, events,
+    and metrics.
 
-    Spans are keyed by ``type:`` and events by ``name:``; we prepend
-    ``span.`` / ``event.`` here so callers can address them with stable
-    ids like ``span.gen_ai.inference.client``."""
+    Spans are keyed by ``type:`` and events/metrics by ``name:``; we prepend
+    ``span.`` / ``event.`` / ``metric.`` here so callers can address them with
+    stable ids like ``span.gen_ai.inference.client``."""
     groups: dict[str, dict] = {}
     for path in sorted(_MODEL_DIR.glob("*.yaml")):
         doc = yaml.safe_load(path.read_text("utf-8")) or {}
@@ -42,6 +42,9 @@ def _load_groups() -> dict[str, dict]:
         for event in doc.get("events", []) or []:
             if "name" in event:
                 groups[f"event.{event['name']}"] = event
+        for metric in doc.get("metrics", []) or []:
+            if "name" in metric:
+                groups[f"metric.{metric['name']}"] = metric
     return groups
 
 
@@ -214,8 +217,15 @@ EVENT_SPECS: dict[str, AttributeSpec] = {
     ),
 }
 
-# No METRIC_SPECS yet: gen_ai.* metrics are deliberately omitted from the reference
-# coverage matrix because the two non-streaming metrics
-# (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`) are
-# derivable from data already present on inference spans (span start/end and
-# `gen_ai.usage.{input,output}_tokens`). Reference scenarios emit spans only.
+METRIC_SPECS: dict[str, AttributeSpec] = {
+    "gen_ai.client.token.usage": _from_yaml(
+        _groups,
+        "metric.gen_ai.client.token.usage",
+        label="Client Token Usage",
+    ),
+    "gen_ai.client.operation.duration": _from_yaml(
+        _groups,
+        "metric.gen_ai.client.operation.duration",
+        label="Client Operation Duration",
+    ),
+}

--- a/reference/tests/test_parse_results.py
+++ b/reference/tests/test_parse_results.py
@@ -83,3 +83,30 @@ def test_unrecognized_metric_warns(tmp_path: Path, caplog):
 
     assert "unrecognized metric" in caplog.text
     assert "gen_ai.client.not_a_metric" in caplog.text
+
+
+def test_error_path_metric_records_error_type(tmp_path: Path):
+    """An operation.duration data point with error.type is detected as an exercised attribute."""
+    result = _parse_samples(
+        tmp_path,
+        [
+            {
+                "metric": {
+                    "name": "gen_ai.client.operation.duration",
+                    "data_points": [
+                        {
+                            "attributes": [
+                                {"name": "gen_ai.operation.name", "value": "chat"},
+                                {"name": "gen_ai.provider.name", "value": "anthropic"},
+                                {"name": "gen_ai.request.model", "value": "claude-sonnet-4-20250514"},
+                                {"name": "error.type", "value": "APIConnectionError"},
+                            ]
+                        }
+                    ],
+                }
+            }
+        ],
+    )
+
+    assert result.detected.metrics["gen_ai.client.operation.duration"] == 1
+    assert "error.type" in result.detected.metric_attrs.get("gen_ai.client.operation.duration", set())

--- a/reference/tests/test_parse_results.py
+++ b/reference/tests/test_parse_results.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from pathlib import Path
+
+from semconv_genai.parse_results import parse_result_dir
+
+
+def _no_spans(_span_name: str, _span_kind: str, _span_attrs: dict[str, object]) -> set[str]:
+    return set()
+
+
+def _parse_samples(tmp_path: Path, samples: list[dict[str, object]]):
+    (tmp_path / "result.json").write_text(json.dumps({"samples": samples}), encoding="utf-8")
+    result = parse_result_dir(tmp_path, "test-library", _no_spans)
+    assert result is not None
+    return result
+
+
+def _metric_data_point(token_type: str) -> dict[str, object]:
+    return {
+        "attributes": [
+            {"name": "gen_ai.operation.name", "value": "chat"},
+            {"name": "gen_ai.provider.name", "value": "anthropic"},
+            {"name": "gen_ai.request.model", "value": "claude-sonnet-4-20250514"},
+            {"name": "gen_ai.token.type", "value": token_type},
+        ]
+    }
+
+
+def test_metric_with_multiple_data_points_counts_once(tmp_path: Path):
+    result = _parse_samples(
+        tmp_path,
+        [
+            {
+                "metric": {
+                    "name": "gen_ai.client.token.usage",
+                    "data_points": [
+                        _metric_data_point("input"),
+                        _metric_data_point("output"),
+                    ],
+                }
+            }
+        ],
+    )
+
+    assert result.detected.metrics["gen_ai.client.token.usage"] == 1
+
+
+def test_non_dict_data_points_warns_and_skips(tmp_path: Path, caplog):
+    caplog.set_level(logging.WARNING, logger="semconv_genai.parse_results")
+
+    result = _parse_samples(
+        tmp_path,
+        [
+            {
+                "metric": {
+                    "name": "gen_ai.client.token.usage",
+                    "data_points": "not-a-data-point",
+                }
+            }
+        ],
+    )
+
+    assert result.detected.metrics == {}
+    assert "invalid data_points" in caplog.text
+    assert "gen_ai.client.token.usage" in caplog.text
+
+
+def test_unrecognized_metric_warns(tmp_path: Path, caplog):
+    caplog.set_level(logging.WARNING, logger="semconv_genai.parse_results")
+
+    _parse_samples(
+        tmp_path,
+        [
+            {
+                "metric": {
+                    "name": "gen_ai.client.not_a_metric",
+                    "data_points": [_metric_data_point("input")],
+                }
+            }
+        ],
+    )
+
+    assert "unrecognized metric" in caplog.text
+    assert "gen_ai.client.not_a_metric" in caplog.text


### PR DESCRIPTION
## Description

Adds the first metrics coverage to the reference scenarios. The `anthropic` chat scenario now emits the two core GenAI client metrics — `gen_ai.client.token.usage` and `gen_ai.client.operation.duration` — alongside its existing spans and events, and the tooling captures and reports them. Addresses #281, starting with `anthropic` as the first library.

## Motivation

The reference scenarios validate which libraries produce which telemetry. Spans and events were covered, but metrics had no coverage at all: there was no meter helper in the shared framework and no Metrics report. This adds the missing third signal so the reference data and the README status reflect metric support, not just spans and events.

## Prototype

The `anthropic` scenario emits the metrics; the committed `data.json` and the new README **Metrics** section are regenerated from a real run (`uv run run-scenario anthropic && uv run update-reports`). A new Metrics report section is rendered parallel to the existing Spans and Events tables.

## Open questions

- Started with `anthropic` and the two client metrics as a minimal slice — happy to fan out to other libraries in follow-ups.
- Rendered metrics as their own report section; happy to fold them into the per-span reports instead if you prefer a different shape.

## Checklist

- [x] Reference scenarios updated for the affected library (`anthropic`)
- [x] Motivation section filled in above
- [ ] Towncrier fragment — not needed (reference tooling, no convention change)
