### PR TITLE
Update Makefile to include reference reports in generate-all

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,8 @@ through several coupled surfaces:
   `make generate-all`.
 - `reference/scenarios/<library>/` — runnable Python reference scenarios
   (`scenario.py`) that prove proposed conventions are capturable.
+- `reference/README.md` and `reference/reports/` — telemetry compliance
+  reports, refreshed by `make generate-all`.
 
 ## PR scope
 

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -45,10 +45,9 @@ If the value would have to be guessed, carried forward from an unrelated call, o
 3. Inventory the Python libraries in this repository that implement the affected operation.
 4. For each library, decide whether the changed fields are credibly available from the current call boundary.
 5. Add or update the reference scenario for every supporting library following [reference-scenarios.instructions.md](../../instructions/reference-scenarios.instructions.md).
-6. Regenerate downstream outputs in dependency order:
+6. Regenerate downstream outputs:
    - Refresh each updated scenario's `reference/scenarios/<library>/data.json` by running its scenario.
-   - Regenerate `reference/reports/*.md` via `uv run update-reports` (see [reference/README.md](../../../reference/README.md)).
-   - If the change also touches `model/**` or `docs/gen-ai/**`, regenerate the registry and docs via `make generate-all` (see `.github/copilot-instructions.md`).
+   - Run `make generate-all` from the repository root to regenerate the registry, docs, and status reports.
 7. Keep unsupported libraries honest. If a library cannot credibly emit a field, leave it out and record it as a capture gap (see [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md)).
 8. Run targeted validation for the changed libraries when feasible.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - uses: ./.github/actions/setup-reference-tooling
 
       - name: Generate status report
-        run: uv run update-reports
+        run: uv run --locked update-reports
 
       - name: Check status report is up to date
         run: git diff --exit-code -- README.md reports/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ make generate-all
 
 This regenerates the attribute registry pages under `docs/registry/`,
 refreshes the generated tables embedded in the hand-written docs under
-`docs/gen-ai/`, and updates the committed schema snapshot under
-`schema-snapshot/`.
+`docs/gen-ai/`, updates the committed schema snapshot under
+`schema-snapshot/`, and regenerates the status reports.
 
 ### 3. Validate
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ SC_UPSTREAM_MIGRATED_DIRS := gen-ai mcp openai
 # same group id.
 SC_UPSTREAM_MIGRATED_GROUPS := aws/registry.yaml:registry.aws.bedrock
 
-.PHONY: check-policies schema-snapshot generate-registry generate-docs generate-json-schemas generate-all clean filter-upstream package-dev
+.PHONY: check-policies schema-snapshot generate-registry generate-docs generate-json-schemas generate-all clean filter-upstream package-dev \
+	generate-reference-reports
 
 # Pinned upstream GitHub URL base, passed to templates as `upstream_docs_base`
 # so cross-registry links to upstream pages resolve to the pinned version.
@@ -147,9 +148,13 @@ generate-docs: $(SC_UPSTREAM_STAMP)
 generate-json-schemas:
 	cd docs/gen-ai/non-normative && uv run models.py
 
-# Run every regeneration the repo owns (weaver-driven + pydantic-driven).
-# CI runs this and fails if any committed output is out of sync.
-generate-all: schema-snapshot generate-registry generate-docs generate-json-schemas
+# Update reference reports (README.md and reports/) from data.json files.
+generate-reference-reports:
+	cd reference && uv run --frozen update-reports
+
+# Run every regeneration the repo owns (weaver-driven + pydantic-driven + reports).
+# CI checks that all committed outputs match what this target generates.
+generate-all: schema-snapshot generate-registry generate-docs generate-json-schemas generate-reference-reports
 
 # Render the resolved registry as a single committed YAML so reviewers can see
 # schema-level changes in PR diffs.


### PR DESCRIPTION
## Description

Include reference reports regeneration in `make generate-all`. 

Also updates `CONTRIBUTING.md` and repository instructions (`SKILL.md`, `copilot-instructions.md`) to match.

## Motivation

So we don't have to remember to run `update-reports` separately when updating scenario data. It's easy to forget and cause CI failures.

## Prototype

N/A

## Checklist

- [x] Motivation section filled in above
- [ ] Reference scenarios updated for affected libraries (N/A)
- [ ] Towncrier fragment added under `changelog.d/` (N/A)
