### PR TITLE
Avoid refreshed reviewer-wait initial notifications

### DIFF
--- a/.github/scripts/pull-request-dashboard/notifications.py
+++ b/.github/scripts/pull-request-dashboard/notifications.py
@@ -117,9 +117,10 @@ def pending_notification_kind(
         return "initial"
     elapsed_seconds = (now - last_notified).total_seconds()
     if current_waiting_since > last_notified:
-        if elapsed_seconds < REVIEWER_FOLLOW_UP_SECONDS:
-            return None
-        return "initial"
+        waiting_seconds = (now - current_waiting_since).total_seconds()
+        if is_notification_weekday(now) and waiting_seconds >= REVIEWER_FOLLOW_UP_SECONDS:
+            return "follow-up"
+        return None
     if is_notification_weekday(now) and elapsed_seconds >= REVIEWER_FOLLOW_UP_SECONDS:
         return "follow-up"
     return None


### PR DESCRIPTION
Avoid sending a fresh “moved to waiting on reviewers” Slack notification when a PR is already waiting on reviewers and only its waiting_since timestamp advanced. Refreshed waits now stay quiet until the newer waiting period reaches the normal follow-up cadence, at which point they are treated as regular follow-ups.