### PR TITLE
Fix Copilot dashboard delegator detection

### DIFF
--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -207,6 +207,12 @@ _MAINTENANCE_BOT_PR_AUTHORS = {"app/otelbot", "app/renovate"}
 
 
 def human_author_for_copilot_pr(raw: dict[str, Any]) -> str:
+    assignees = [actor_login(a) for a in (raw["pr"].get("assignees") or [])]
+    for login in assignees:
+        low = login.lower()
+        if login and low not in _COPILOT_PR_AUTHORS and not low.endswith("[bot]"):
+            return login
+
     commits = raw["commits"]
     if not commits:
         return ""

--- a/.github/scripts/pull-request-dashboard/dashboard.py
+++ b/.github/scripts/pull-request-dashboard/dashboard.py
@@ -210,7 +210,7 @@ def human_author_for_copilot_pr(raw: dict[str, Any]) -> str:
     assignees = [actor_login(a) for a in (raw["pr"].get("assignees") or [])]
     for login in assignees:
         low = login.lower()
-        if login and low not in _COPILOT_PR_AUTHORS and not low.endswith("[bot]"):
+        if login and low not in _COPILOT_PR_AUTHORS and not low.startswith("app/") and not low.endswith("[bot]"):
             return login
 
     commits = raw["commits"]


### PR DESCRIPTION
Prefer a non-bot assignee as the human delegator for Copilot-authored PRs before falling back to commit committer metadata. This prevents dashboard rows for Copilot PRs created through GitHub's web flow from showing the synthetic web-flow committer instead of the human delegator.