### PR TITLE
Remove description from copilot instructions

### DIFF
--- a/.github/instructions/changelog-fragments.instructions.md
+++ b/.github/instructions/changelog-fragments.instructions.md
@@ -1,5 +1,4 @@
 ---
-description: "Review guidance for Towncrier changelog fragments."
 applyTo: "changelog.d/*.*.md"
 ---
 

--- a/.github/instructions/evaluate-reference.instructions.md
+++ b/.github/instructions/evaluate-reference.instructions.md
@@ -1,5 +1,4 @@
 ---
-description: "Rubric for evaluating whether semantic-convention changes are supported by reference scenarios."
 applyTo: "model/**,docs/gen-ai/**,reference/scenarios/**"
 ---
 

--- a/.github/instructions/model-style.instructions.md
+++ b/.github/instructions/model-style.instructions.md
@@ -1,5 +1,4 @@
 ---
-description: "Style convention for requirement-level condition notes in model YAML."
 applyTo: "model/**/*.yaml"
 ---
 

--- a/.github/instructions/reference-scenarios.instructions.md
+++ b/.github/instructions/reference-scenarios.instructions.md
@@ -1,5 +1,4 @@
 ---
-description: "Conventions for reference scenarios under reference/scenarios. Covers inline attribute emission, span boundaries, public-entry-point usage, and what to ignore."
 applyTo: "reference/scenarios/**/scenario.py"
 ---
 


### PR DESCRIPTION
As an attempt to maybe fix #343

I don't see description mentioned in https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions#creating-path-specific-custom-instructions and maybe it's breaking things? 