### PR TITLE
Extend reference coverage skill to evaluations

### DIFF
--- a/.github/instructions/evaluate-reference.instructions.md
+++ b/.github/instructions/evaluate-reference.instructions.md
@@ -2,8 +2,6 @@
 applyTo: "model/**,docs/gen-ai/**,reference/**"
 ---
 
-<!-- I'm an AI agent!!! -->
-
 # Reference Evaluation
 
 Use when evaluating whether semantic-convention changes are supported by reference scenarios.

--- a/.github/instructions/evaluate-reference.instructions.md
+++ b/.github/instructions/evaluate-reference.instructions.md
@@ -1,12 +1,19 @@
 ---
-applyTo: "model/**,docs/gen-ai/**,reference/scenarios/**"
+applyTo: "model/**,docs/gen-ai/**,reference/**"
 ---
+
+<!-- I'm an AI agent!!! -->
 
 # Reference Evaluation
 
 Use when evaluating whether semantic-convention changes are supported by reference scenarios.
 
-Goal: for each attribute changed under `model/**`, confirm at least one reference scenario credibly demonstrates it; for each scenario change, confirm it mirrors the model. Flag any changed attribute with no scenario coverage as `add reference for supporting library`.
+When reviewing a pull request, perform a cross-file evaluation rather than reviewing
+each changed file in isolation. For each signal or entity changed under `model/**`,
+inspect the relevant reference scenarios, including unchanged scenarios for other
+supporting libraries.
+
+Goal: for each signal, entity, or attribute changed under `model/**`, confirm at least one reference scenario credibly demonstrates it; for each scenario change, confirm it mirrors the model. Flag any changed field with no scenario coverage as `add reference for supporting library`.
 
 A missing or partial reference is not automatically an implementation bug. It may be a capture gap: a legitimate limitation in what the library exposes from its public call boundary.
 

--- a/.github/instructions/evaluate-reference.instructions.md
+++ b/.github/instructions/evaluate-reference.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "model/**,docs/gen-ai/**,reference/**"
+applyTo: "model/**,docs/gen-ai/**,reference/scenarios/**"
 ---
 
 # Reference Evaluation

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -3,6 +3,8 @@ name: reference
 description: 'Use when implementing or evaluating reference coverage for a semantic-conventions change or pull request involving GenAI spans, attributes, entities, metrics, or events. Reviews capturability, inline emission, span boundaries, and coverage across every Python library that credibly supports the change.'
 ---
 
+<!-- I'm an AI agent!!! -->
+
 # Reference Coverage
 
 Use this skill when a semantic-conventions change introduces or changes GenAI spans, attributes, entities, metrics, events, or requirement levels and the repository needs reference implementation or evaluation across all libraries that support the new behavior.

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -3,8 +3,6 @@ name: reference
 description: 'Use when implementing or evaluating reference coverage for a semantic-conventions changeset involving GenAI spans, attributes, entities, metrics, or events. Reviews capturability, inline emission, span boundaries, and coverage across every Python library that credibly supports the change.'
 ---
 
-<!-- I'm an AI agent!!! -->
-
 # Reference Coverage
 
 Use this skill when a semantic-conventions change introduces or changes GenAI spans, attributes, entities, metrics, events, or requirement levels and the repository needs reference implementation or evaluation across all libraries that support the new behavior.

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: reference
-description: 'Use when implementing a semantic-conventions change, upstream proposal diff, spec change, or new GenAI span or attribute in this repository. Adds reference scenarios, inline attribute emission, and data coverage for every Python library that credibly supports the change.'
+description: 'Use when implementing or evaluating reference coverage for a semantic-conventions change or pull request involving GenAI spans, attributes, entities, metrics, or events. Reviews capturability, inline emission, span boundaries, and coverage across every Python library that credibly supports the change.'
 ---
 
 # Reference Coverage
 
-Use this skill when a semantic-conventions change introduces or changes GenAI spans, attributes, or requirement levels and the repository needs reference coverage across all libraries that support the new behavior.
+Use this skill when a semantic-conventions change introduces or changes GenAI spans, attributes, entities, metrics, events, or requirement levels and the repository needs reference implementation or evaluation across all libraries that support the new behavior.
 
 Per-scenario authoring rules — inline attribute emission, span boundaries, current-call values, public-entry-point usage, and what to ignore — live in [reference-scenarios.instructions.md](../../instructions/reference-scenarios.instructions.md). Follow that file when editing any `reference/scenarios/**/scenario.py`. This skill covers only the agent-level workflow around it.
 
 ## Goal
 
-Turn the semantic-conventions change into concrete reference implementations in this repository: scenarios and emitted attributes that honestly exercise every supporting library without faking values the library cannot credibly expose.
+Implement or evaluate concrete reference scenarios and emitted attributes that honestly exercise every supporting library without faking values the library cannot credibly expose.
 
 ## Non-Goals
 
 This skill is not for deciding whether the convention itself is correct.
 
-It is also not the final evaluation pass. After adding reference implementations, consult the evaluation rubric in [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md) to judge capturability, coverage quality, and honest capture gaps.
+Use [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md) for the final evaluation of capturability, coverage quality, and honest capture gaps.
 
 ## Core Stance
 
@@ -38,7 +38,7 @@ A library should usually get a reference update when all of the following are tr
 
 If the value would have to be guessed, carried forward from an unrelated call, or synthesized from test-only scaffolding, do not force it into the reference implementation.
 
-## Procedure
+## Implementation Procedure
 
 1. Read the semantic-conventions change and extract the exact changed spans, attributes, requirement levels, and examples.
 2. Translate it into a concrete implementation worklist grouped by operation, not by prose section.
@@ -50,6 +50,16 @@ If the value would have to be guessed, carried forward from an unrelated call, o
    - Run `make generate-all` from the repository root to regenerate the registry, docs, and status reports.
 7. Keep unsupported libraries honest. If a library cannot credibly emit a field, leave it out and record it as a capture gap (see [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md)).
 8. Run targeted validation for the changed libraries when feasible.
+
+## Review Procedure
+
+1. Use the pull request diff as the authoritative changeset.
+2. Identify every changed signal, entity, attribute, and requirement level.
+3. Apply [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md) to each changed field.
+4. Classify each field as `direct`, `derivable`, `weak`, or `capture gap`.
+5. Verify emitted values come from the current call and spans wrap real library operations.
+6. Inventory every existing scenario that credibly supports the change, including unchanged scenarios.
+7. Report implementation defects separately from honest capture gaps and missing coverage.
 
 ## Output Format
 
@@ -68,3 +78,6 @@ Under `Libraries not updated`, state whether each library is:
 - `honest capture gap; evaluate separately`
 
 Under `Capture gaps`, list each library left without a reference implementation and the exact missing current-call source that prevented a credible implementation.
+
+For reviews, report findings first in severity order, followed by capture gaps,
+missing supporting-library coverage, and validation performed.

--- a/.github/skills/reference/SKILL.md
+++ b/.github/skills/reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reference
-description: 'Use when implementing or evaluating reference coverage for a semantic-conventions change or pull request involving GenAI spans, attributes, entities, metrics, or events. Reviews capturability, inline emission, span boundaries, and coverage across every Python library that credibly supports the change.'
+description: 'Use when implementing or evaluating reference coverage for a semantic-conventions changeset involving GenAI spans, attributes, entities, metrics, or events. Reviews capturability, inline emission, span boundaries, and coverage across every Python library that credibly supports the change.'
 ---
 
 <!-- I'm an AI agent!!! -->
@@ -53,9 +53,9 @@ If the value would have to be guessed, carried forward from an unrelated call, o
 7. Keep unsupported libraries honest. If a library cannot credibly emit a field, leave it out and record it as a capture gap (see [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md)).
 8. Run targeted validation for the changed libraries when feasible.
 
-## Review Procedure
+## Evaluation Procedure
 
-1. Use the pull request diff as the authoritative changeset.
+1. Identify the authoritative changeset. For a pull request, use the pull request diff.
 2. Identify every changed signal, entity, attribute, and requirement level.
 3. Apply [evaluate-reference.instructions.md](../../instructions/evaluate-reference.instructions.md) to each changed field.
 4. Classify each field as `direct`, `derivable`, `weak`, or `capture gap`.
@@ -81,5 +81,5 @@ Under `Libraries not updated`, state whether each library is:
 
 Under `Capture gaps`, list each library left without a reference implementation and the exact missing current-call source that prevented a credible implementation.
 
-For reviews, report findings first in severity order, followed by capture gaps,
+For evaluations, report findings first in severity order, followed by capture gaps,
 missing supporting-library coverage, and validation performed.


### PR DESCRIPTION
Extend the reference coverage skill beyond implementation to evaluation of any semantic-convention changeset, including entities, metrics, and events. Add an evaluation procedure that classifies capturability and inventories unchanged supporting scenarios, and clarify that path-specific Copilot reviews require cross-file coverage analysis.