### PR TITLE
Sync stale core semconv version references with the versions.env pin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ changes, not a skill to invoke.
 
 ## Further reading
 
-- [How to write conventions — best practices](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/how-to-write-conventions/README.md#best-practices)
-- [Naming](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/general/naming.md)
-- [Events](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/general/events.md)
-- [Recording errors](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/general/recording-errors.md)
+- [How to write conventions — best practices](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/how-to-write-conventions/README.md#best-practices)
+- [Naming](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/general/naming.md)
+- [Events](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/general/events.md)
+- [Recording errors](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/general/recording-errors.md)

--- a/docs/gen-ai/gen-ai-metrics.md
+++ b/docs/gen-ai/gen-ai-metrics.md
@@ -905,7 +905,7 @@ This metric SHOULD be specified with [ExplicitBucketBoundaries] of [1, 5, 10, 30
 | `gen_ai.workflow.duration` | Histogram | `s` | GenAI workflow duration. [1] | ![Development](https://img.shields.io/badge/-development-blue) | |
 
 **[1]:** This metric instrument describes an operation that executes a coordinated process composed of multiple agents or other operations involving generative AI.
-When this metric is reported alongside a `gen_ai.invoke_workflow` span, the metric  value SHOULD be the same as the span duration.
+When this metric is reported alongside a `gen_ai.invoke_workflow` span, the metric value SHOULD be the same as the span duration.
 
 **Requirement level:** [Recommended](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/signal-requirement-level.md).
 

--- a/model/manifest.yaml
+++ b/model/manifest.yaml
@@ -8,12 +8,13 @@ schema_url: https://opentelemetry.io/schemas/gen-ai-dev/1.42.0-dev
 stability: development
 dependencies:
   # NOTE: This is a local filtered copy of
-  # https://github.com/open-telemetry/semantic-conventions.git@v1.41.0[model]
-  # with the gen-ai/, mcp/, and openai/ subdirectories removed. This repo is
-  # the canonical home for those conventions going forward; until upstream
-  # deletes its copies we strip them here so Weaver does not see the same
-  # group ids defined in two places. The Makefile target that produces
-  # `.build/sc-upstream-filtered` is invoked automatically by every
-  # generate / check target (e.g. `check-policies`, `generate-all`).
-  - schema_url: https://opentelemetry.io/schemas/1.41.0
+  # https://github.com/open-telemetry/semantic-conventions.git[model] at the
+  # SEMCONV_VERSION pinned in versions.env, with the gen-ai/, mcp/, and
+  # openai/ subdirectories removed. This repo is the canonical home for those
+  # conventions going forward; until upstream deletes its copies we strip them
+  # here so Weaver does not see the same group ids defined in two places. The
+  # Makefile target that produces `.build/sc-upstream-filtered` is invoked
+  # automatically by every generate / check target (e.g. `check-policies`,
+  # `generate-all`). Keep the schema_url below in sync with SEMCONV_VERSION.
+  - schema_url: https://opentelemetry.io/schemas/1.43.0
     registry_path: ./.build/sc-upstream-filtered


### PR DESCRIPTION
## What

`versions.env` is the single source of truth for the pinned core semantic-conventions version (`SEMCONV_VERSION`, currently `v1.43.0`, tracked by Renovate). Two hand-maintained references to that version were left behind by the last bump and this PR brings them back in sync:

- **`model/manifest.yaml`** — the filtered upstream dependency still declared `https://opentelemetry.io/schemas/1.41.0` (in both the comment and the `schema_url`), while the Makefile actually clones the tag pinned in `versions.env` into `.build/sc-upstream-filtered`. The comment now points at `versions.env` as the source of truth instead of hardcoding a tag, and the `schema_url` is bumped to `1.43.0`.
- **`AGENTS.md`** — the four "Further reading" links pointed at `blob/v1.42.0`; bumped to `blob/v1.43.0`. All four targets verified reachable at that tag (HTTP 200).

Also included: a whitespace normalization in `docs/gen-ai/gen-ai-metrics.md` that `make generate-all` produces on current `main` (the committed generated output had drifted from `model/gen-ai/metrics.yaml`).

## Why this happened

- #342 (2026-06-26) added `AGENTS.md` with `v1.42.0` links — current at the time.
- #366 (2026-07-04) bumped `SEMCONV_VERSION` to `v1.43.0`; Renovate's custom manager only tracks `versions.env`, and `make generate-all` only regenerates the generated docs — so the hand-written `AGENTS.md` links and the `manifest.yaml` dependency declaration were not updated.

No behavior change: the build already uses `v1.43.0`; this only makes the declared metadata and docs match reality. If it's useful, a follow-up could add Renovate regex managers for these two spots so they can't drift again.

`make check-policies` and `make generate-all` pass locally with no further diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)