### PR TITLE
Make `gen_ai.retrieval.documents` `id`/`score` optional (#344)

### DIFF
--- a/changelog.d/395.clarification.md
+++ b/changelog.d/395.clarification.md
@@ -1,0 +1,1 @@
+Relax `gen_ai.retrieval.documents` `id` and `score` from recommended to optional, since retrieval libraries (e.g. LangChain) may not always expose a document id or a relevance score.

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -573,7 +573,7 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 
 **[7] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
-**[8] `gen_ai.retrieval.documents`:** Each document object SHOULD contain at least the following properties:
+**[8] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -464,8 +464,8 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str = Field(description="A unique identifier for the document.")
-    score: float = Field(description="The relevance score of the document.")
+    id: Optional[str] = Field(default=None, description="A unique identifier for the document.")
+    score: Optional[float] = Field(default=None, description="The relevance score of the document.")
 
     model_config = ConfigDict(
         extra="allow"

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -184,7 +184,7 @@ Semantic conventions for individual providers SHOULD document which input parame
 
 **[18] `gen_ai.request.top_k`:** This is a decoding/sampling parameter (e.g., Anthropic `top_k`, Cohere `k`, Google `topK`), not an output-shaping parameter. In particular, OpenAI's `top_logprobs` controls how many per-token log-probabilities are returned in the response and does not change generation; it MUST NOT be reported as `gen_ai.request.top_k`.
 
-**[19] `gen_ai.retrieval.documents`:** Each document object SHOULD contain at least the following properties:
+**[19] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,20 +5,32 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "A unique identifier for the document.",
-                    "title": "Id",
-                    "type": "string"
+                    "title": "Id"
                 },
                 "score": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "The relevance score of the document.",
-                    "title": "Score",
-                    "type": "number"
+                    "title": "Score"
                 }
             },
-            "required": [
-                "id",
-                "score"
-            ],
             "title": "RetrievalDocument",
             "type": "object"
         }

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -550,7 +550,7 @@ attributes:
       type:
         json_schema: model/gen-ai/gen-ai-retrieval-documents.json
     note: |
-      Each document object SHOULD contain at least the following properties:
+      Each document object MAY contain the following properties when available:
       `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
     examples:
       - |


### PR DESCRIPTION
## What

Relax `gen_ai.retrieval.documents` `id` and `score` from recommended to optional.

Retrieval libraries may not always expose a document id or a relevance score. For example, LangChain's `Document.id` is `Optional[str]`, and `on_retriever_end` receives `Sequence[Document]` with no `score` field. Requiring these properties forces instrumentations to fabricate values, which is worse than omission.

## Changes

- Make `RetrievalDocument.id` / `score` `Optional` with `default=None` in the pydantic source in `docs/gen-ai/non-normative/models.py`. The JSON schema is generated from this model.
- Update the registry note from "SHOULD contain at least the following properties" to "MAY contain the following properties when available" (`model/gen-ai/registry.yaml`).
- Regenerate the affected artifacts: `model/gen-ai/gen-ai-retrieval-documents.json` (fields now nullable and removed from `required`), `docs/registry/attributes/gen-ai.md`, `docs/gen-ai/gen-ai-spans.md`.

The fields and their descriptions are retained, so existing consumers that read `id` / `score` when present keep working, and documents that populate them still validate.

## Verification

- `make generate-all` — clean diff (only the intended generated files).
- `make check-policies` — passes (no policy violation).
- `cd reference && uv run run-scenario langchain` — the langchain scenario emits retrieval documents without `id`/`score` and validates (`data.json` unchanged).

## Related

- Closes #344
- Unblocks the downstream instrumentation work tracked in opentelemetry-python-genai#124.