### PR TITLE
#344 Make retrieval document id and score optional

### DIFF
--- a/changelog.d/+.bugfix.md
+++ b/changelog.d/+.bugfix.md
@@ -1,0 +1,1 @@
+Make retrieval document `id` and `score` optional so instrumentations can omit values that are unavailable at runtime.

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -580,7 +580,7 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 
 **[7] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
-**[8] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
+**[8] `gen_ai.retrieval.documents`:** Each document object SHOULD contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/docs/gen-ai/gen-ai-spans.md
+++ b/docs/gen-ai/gen-ai-spans.md
@@ -580,7 +580,7 @@ applicable `aws.bedrock.*` attributes and are not expected to include
 
 **[7] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
-**[8] `gen_ai.retrieval.documents`:** Each document object SHOULD contain at least the following properties:
+**[8] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -34,7 +34,6 @@ from pydantic import (
     GetJsonSchemaHandler,
     RootModel,
 )
-from pydantic.json_schema import SkipJsonSchema
 from pydantic_core import core_schema
 
 
@@ -465,9 +464,8 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str | SkipJsonSchema[None] = Field(
-        default_factory=lambda: None,
-        description="A unique identifier for the document.",
+    id: str | None = Field(
+        default=None, description="A unique identifier for the document."
     )
     score: float | None = Field(
         default=None, description="The relevance score of the document."

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -464,8 +464,12 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str = Field(description="A unique identifier for the document.")
-    score: float = Field(description="The relevance score of the document.")
+    id: Optional[str] = Field(
+        default=None, description="A unique identifier for the document."
+    )
+    score: Optional[float] = Field(
+        default=None, description="The relevance score of the document."
+    )
 
     model_config = ConfigDict(
         extra="allow"

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -34,6 +34,7 @@ from pydantic import (
     GetJsonSchemaHandler,
     RootModel,
 )
+from pydantic.json_schema import SkipJsonSchema
 from pydantic_core import core_schema
 
 
@@ -464,11 +465,13 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: Optional[str] = Field(
-        default=None, description="A unique identifier for the document."
+    id: str | SkipJsonSchema[None] = Field(
+        default_factory=lambda: None,
+        description="A unique identifier for the document.",
     )
-    score: Optional[float] = Field(
-        default=None, description="The relevance score of the document."
+    score: float | SkipJsonSchema[None] = Field(
+        default_factory=lambda: None,
+        description="The relevance score of the document.",
     )
 
     model_config = ConfigDict(

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -469,9 +469,8 @@ class RetrievalDocument(BaseModel):
         default_factory=lambda: None,
         description="A unique identifier for the document.",
     )
-    score: float | SkipJsonSchema[None] = Field(
-        default_factory=lambda: None,
-        description="The relevance score of the document.",
+    score: float | None = Field(
+        default=None, description="The relevance score of the document."
     )
 
     model_config = ConfigDict(

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -189,7 +189,7 @@ Semantic conventions for individual providers SHOULD document which input parame
 
 **[19] `gen_ai.request.top_k`:** This is a decoding/sampling parameter (e.g., Anthropic `top_k`, Cohere `k`, Google `topK`), not an output-shaping parameter. In particular, OpenAI's `top_logprobs` controls how many per-token log-probabilities are returned in the response and does not change generation; it MUST NOT be reported as `gen_ai.request.top_k`.
 
-**[20] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
+**[20] `gen_ai.retrieval.documents`:** Each document object SHOULD contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -189,7 +189,7 @@ Semantic conventions for individual providers SHOULD document which input parame
 
 **[19] `gen_ai.request.top_k`:** This is a decoding/sampling parameter (e.g., Anthropic `top_k`, Cohere `k`, Google `topK`), not an output-shaping parameter. In particular, OpenAI's `top_logprobs` controls how many per-token log-probabilities are returned in the response and does not change generation; it MUST NOT be reported as `gen_ai.request.top_k`.
 
-**[20] `gen_ai.retrieval.documents`:** Each document object SHOULD contain at least the following properties:
+**[20] `gen_ai.retrieval.documents`:** Each document object MAY contain the following properties when available:
 `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
 
 Instrumentations MUST follow [JSON schema](/model/gen-ai/gen-ai-retrieval-documents.json).

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,20 +5,32 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "A unique identifier for the document.",
-                    "title": "Id",
-                    "type": "string"
+                    "title": "Id"
                 },
                 "score": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "The relevance score of the document.",
-                    "title": "Score",
-                    "type": "number"
+                    "title": "Score"
                 }
             },
-            "required": [
-                "id",
-                "score"
-            ],
             "title": "RetrievalDocument",
             "type": "object"
         }

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,30 +5,14 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
                     "description": "A unique identifier for the document.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "score": {
-                    "anyOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
                     "description": "The relevance score of the document.",
-                    "title": "Score"
+                    "title": "Score",
+                    "type": "number"
                 }
             },
             "title": "RetrievalDocument",

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,9 +5,17 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "A unique identifier for the document.",
-                    "title": "Id",
-                    "type": "string"
+                    "title": "Id"
                 },
                 "score": {
                     "anyOf": [

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -10,9 +10,17 @@
                     "type": "string"
                 },
                 "score": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "The relevance score of the document.",
-                    "title": "Score",
-                    "type": "number"
+                    "title": "Score"
                 }
             },
             "title": "RetrievalDocument",

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -559,7 +559,7 @@ attributes:
       type:
         json_schema: model/gen-ai/gen-ai-retrieval-documents.json
     note: |
-      Each document object MAY contain the following properties when available:
+      Each document object SHOULD contain the following properties when available:
       `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
     examples:
       - |

--- a/model/gen-ai/registry.yaml
+++ b/model/gen-ai/registry.yaml
@@ -559,7 +559,7 @@ attributes:
       type:
         json_schema: model/gen-ai/gen-ai-retrieval-documents.json
     note: |
-      Each document object SHOULD contain at least the following properties:
+      Each document object MAY contain the following properties when available:
       `id` (string): A unique identifier for the document, `score` (double): The relevance score of the document
     examples:
       - |


### PR DESCRIPTION
## Description

Fixes https://github.com/open-telemetry/semantic-conventions-genai/issues/344
Closes #395 

Make id and score optional properties of gen_ai.retrieval.documents.

This allows instrumentations to omit values instead of fabricating them.

## Motivation

Retrieval frameworks do not consistently expose document identifiers or relevance scores. For example, LangChain document identifiers are optional, and its retriever callback receives documents without their relevance scores.

## Prototype

The existing LangChain reference scenario invokes the public retriever API and emits retrieval documents containing available content and metadata without id or score.

## Checklist

- [x] Motivation section filled in above
- [x] Reference scenarios updated for affected libraries
- [x] Towncrier fragment added under `changelog.d/` for any change to the conventions that a consumer would care about. Editorial changes (typos, pure rewording, repo tooling) don't need an entry.

See [CONTRIBUTING.md]
