### PR TITLE
Include markdown snippets into consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,12 @@ jobs:
       - name: Regenerate and check committed outputs are in sync
         run: |
           make generate-all
-          if ! git diff --exit-code -- ./docs/registry 'model/gen-ai/gen-ai-*.json'; then
+          if ! git diff --exit-code -- ./docs 'model/gen-ai/gen-ai-*.json'; then
             echo "FAIL: committed generated outputs are out of sync!"
             echo "Run 'make generate-all' and commit the changes."
             exit 1
           fi
-          untracked=$(git ls-files --others --exclude-standard -- ./docs/registry 'model/gen-ai/gen-ai-*.json')
+          untracked=$(git ls-files --others --exclude-standard -- ./docs 'model/gen-ai/gen-ai-*.json')
           if [ -n "$untracked" ]; then
             echo "FAIL: untracked files under generated outputs:"
             echo "$untracked"

--- a/templates/registry/markdown/attribute_macros.j2
+++ b/templates/registry/markdown/attribute_macros.j2
@@ -23,13 +23,13 @@
 {{ group_id | split_id | join(" ") | title_case | acronym }} Attributes
 {%- endmacro %}
 
-{# v2 link rendering: attribute.provenance is set for locally-defined attributes
+{# v2 link rendering: attribute.provenance.path is set for locally-defined attributes
    (their YAML file lives under ./model/) and is null for attributes imported
    from a dependency. Local attributes link to /docs/registry/attributes/<ns>.md;
    imported attributes link to the pinned upstream registry page. #}
 {% macro name_with_link(attribute, attribute_registry_base_url, upstream_docs_base) -%}
 {%- set ns_id = name(attribute) | trim | split_id | first -%}
-[`{{ name(attribute) | trim }}`]({% if attribute.provenance %}{{ attribute_registry_base_url }}/{{ ns_id | kebab_case }}.md{% else %}{{ upstream_docs_base }}/docs/registry/attributes/{{ ns_id | kebab_case }}.md{% endif %})
+[`{{ name(attribute) | trim }}`]({% if attribute.provenance.path %}{{ attribute_registry_base_url }}/{{ ns_id | kebab_case }}.md{% else %}{{ upstream_docs_base }}/docs/registry/attributes/{{ ns_id | kebab_case }}.md{% endif %})
 {%- endmacro %}
 
 {% macro heading_link_fragments(title) %}{{ title | trim | lower | replace(" ", "-") | replace("(", "") | replace(")", "") | replace("/", "") | replace("\\", "") | replace(".", "") | replace("!", "") | replace("?", "") | replace("~", "") | replace("#", "")}}{% endmacro %}


### PR DESCRIPTION
turns out we don't validate markdown snippets generation, only registry - https://github.com/open-telemetry/semantic-conventions-genai/actions/runs/30322560504/job/90161288759?pr=405

Fixing templates to work with new weaver to fix current violations.