### PR TITLE
Disallow null optional GenAI JSON fields

### DIFF
--- a/changelog.d/+.bugfix.2.md
+++ b/changelog.d/+.bugfix.2.md
@@ -1,1 +1,1 @@
-Disallow null values for optional fields in generated GenAI JSON schemas.
+Distinguish omitted and null values in generated GenAI JSON schemas.

--- a/changelog.d/+.bugfix.2.md
+++ b/changelog.d/+.bugfix.2.md
@@ -1,0 +1,1 @@
+Disallow null values for optional fields in generated GenAI JSON schemas.

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -37,6 +37,16 @@ from pydantic import (
 from pydantic_core import core_schema
 
 
+def omittable_field(**kwargs: Any):
+    """Define an optional, non-nullable JSON property."""
+
+    return Field(
+        default=None,
+        json_schema_extra=lambda schema: schema.pop("default", None),
+        **kwargs,
+    )
+
+
 # --------------------------------------------------------------------------
 # Common message-part models
 # --------------------------------------------------------------------------
@@ -63,11 +73,11 @@ class ToolCallRequestPart(BaseModel):
     type: Literal["tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = Field(
-        default=None, description="Unique identifier for the tool call."
+    id: str = omittable_field(
+        description="Unique identifier for the tool call."
     )
     name: str = Field(description="Name of the tool.")
-    arguments: Any = Field(default=None, description="Arguments for the tool call.")
+    arguments: Any = omittable_field(description="Arguments for the tool call.")
 
     model_config = ConfigDict(extra="allow")
 
@@ -80,7 +90,7 @@ class ToolCallResponsePart(BaseModel):
     type: Literal["tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = Field(default=None, description="Unique tool call identifier.")
+    id: str = omittable_field(description="Unique tool call identifier.")
     response: Any = Field(description="Tool call response.")
 
     model_config = ConfigDict(extra="allow")
@@ -122,8 +132,8 @@ class ServerToolCallPart(BaseModel):
     type: Literal["server_tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = Field(
-        default=None, description="Unique identifier for the server tool call."
+    id: str = omittable_field(
+        description="Unique identifier for the server tool call."
     )
     name: str = Field(description="Name of the server tool.")
     server_tool_call: ServerToolCall = Field(
@@ -139,8 +149,7 @@ class ServerToolCallResponsePart(BaseModel):
     type: Literal["server_tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = Field(
-        default=None,
+    id: str = omittable_field(
         description="Unique server tool call identifier matching the original call.",
     )
     server_tool_call_response: ServerToolCallResponse = Field(
@@ -180,12 +189,10 @@ class CompactionPart(BaseModel):
     type: Literal["compaction"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = Field(
-        default=None,
+    id: str = omittable_field(
         description="Provider-assigned identifier for the compaction item or block.",
     )
-    content: str = Field(
-        default=None,
+    content: str = omittable_field(
         description="The unencrypted compacted conversation summary, when available.",
     )
 
@@ -198,8 +205,8 @@ class BlobPart(BaseModel):
     type: Literal["blob"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = Field(
-        default=None, description="The IANA MIME type of the attached data."
+    mime_type: str = omittable_field(
+        description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
@@ -215,8 +222,8 @@ class FilePart(BaseModel):
     type: Literal["file"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = Field(
-        default=None, description="The IANA MIME type of the attached data."
+    mime_type: str = omittable_field(
+        description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
@@ -234,8 +241,8 @@ class UriPart(BaseModel):
     type: Literal["uri"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = Field(
-        default=None, description="The IANA MIME type of the attached data."
+    mime_type: str = omittable_field(
+        description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
         description="The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known."
@@ -304,8 +311,8 @@ class ChatMessage(BaseModel):
     parts: List[MessagePart] = Field(
         description="List of message parts that make up the message content."
     )
-    name: str = Field(
-        default=None, description="The name of the participant."
+    name: str = omittable_field(
+        description="The name of the participant."
     )
 
     model_config = ConfigDict(extra="allow")
@@ -417,16 +424,14 @@ class FunctionToolDefinition(GenericToolDefinition):
     """
 
     type: Literal["function"] = Field(description="The type of the tool.")
-    description: str = Field(
-        default=None,
+    description: str = omittable_field(
         description=(
             "The description of the tool. "
             "Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. "
             "Instrumentations MAY provide a way to enable populating this property."
         ),
     )
-    parameters: JsonSchemaDraft7Dict = Field(
-        default=None,
+    parameters: JsonSchemaDraft7Dict = omittable_field(
         description=(
             "JSON Schema document describing the parameters accepted by the tool. "
             "The value MUST conform to JSON Schema draft-07. "
@@ -464,11 +469,11 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str = Field(
-        default=None, description="A unique identifier for the document."
+    id: str = omittable_field(
+        description="A unique identifier for the document."
     )
-    score: float = Field(
-        default=None, description="The relevance score of the document."
+    score: float = omittable_field(
+        description="The relevance score of the document."
     )
 
     model_config = ConfigDict(
@@ -495,15 +500,13 @@ class MemoryRecord(BaseModel):
     """
 
     content: Any = Field(description="The content of the memory record.")
-    id: str = Field(
-        default=None, description="A unique identifier for the memory record."
+    id: str = omittable_field(
+        description="A unique identifier for the memory record."
     )
-    metadata: dict[str, Any] = Field(
-        default=None,
+    metadata: dict[str, Any] = omittable_field(
         description="Provider-specific metadata associated with the memory record.",
     )
-    score: float = Field(
-        default=None,
+    score: float = omittable_field(
         description="The relevance score of the memory record when populated on search results.",
     )
 

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -35,16 +35,13 @@ from pydantic import (
     RootModel,
 )
 from pydantic_core import core_schema
+from pydantic.experimental.missing_sentinel import MISSING
 
 
 def omittable_field(**kwargs: Any):
-    """Define an optional, non-nullable JSON property."""
+    """Define a property omitted when unavailable."""
 
-    return Field(
-        default=None,
-        json_schema_extra=lambda schema: schema.pop("default", None),
-        **kwargs,
-    )
+    return Field(MISSING, **kwargs)
 
 
 # --------------------------------------------------------------------------
@@ -73,11 +70,16 @@ class ToolCallRequestPart(BaseModel):
     type: Literal["tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = omittable_field(
+    id: str | MISSING = omittable_field(
         description="Unique identifier for the tool call."
     )
     name: str = Field(description="Name of the tool.")
-    arguments: Any = omittable_field(description="Arguments for the tool call.")
+    arguments: Any = omittable_field(
+        description=(
+            "Arguments for the tool call. Omit when they are not captured; "
+            "record null when the call has null arguments."
+        )
+    )
 
     model_config = ConfigDict(extra="allow")
 
@@ -90,8 +92,10 @@ class ToolCallResponsePart(BaseModel):
     type: Literal["tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = omittable_field(description="Unique tool call identifier.")
-    response: Any = Field(description="Tool call response.")
+    id: str | MISSING = omittable_field(description="Unique tool call identifier.")
+    response: Any = Field(
+        description="Tool call response. Null represents a captured null response."
+    )
 
     model_config = ConfigDict(extra="allow")
 
@@ -132,7 +136,7 @@ class ServerToolCallPart(BaseModel):
     type: Literal["server_tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = omittable_field(
+    id: str | MISSING = omittable_field(
         description="Unique identifier for the server tool call."
     )
     name: str = Field(description="Name of the server tool.")
@@ -149,7 +153,7 @@ class ServerToolCallResponsePart(BaseModel):
     type: Literal["server_tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = omittable_field(
+    id: str | MISSING = omittable_field(
         description="Unique server tool call identifier matching the original call.",
     )
     server_tool_call_response: ServerToolCallResponse = Field(
@@ -189,10 +193,10 @@ class CompactionPart(BaseModel):
     type: Literal["compaction"] = Field(
         description="The type of the content captured in this part."
     )
-    id: str = omittable_field(
+    id: str | MISSING = omittable_field(
         description="Provider-assigned identifier for the compaction item or block.",
     )
-    content: str = omittable_field(
+    content: str | MISSING = omittable_field(
         description="The unencrypted compacted conversation summary, when available.",
     )
 
@@ -205,7 +209,7 @@ class BlobPart(BaseModel):
     type: Literal["blob"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = omittable_field(
+    mime_type: str | MISSING = omittable_field(
         description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -222,7 +226,7 @@ class FilePart(BaseModel):
     type: Literal["file"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = omittable_field(
+    mime_type: str | MISSING = omittable_field(
         description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -241,7 +245,7 @@ class UriPart(BaseModel):
     type: Literal["uri"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: str = omittable_field(
+    mime_type: str | MISSING = omittable_field(
         description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -311,7 +315,7 @@ class ChatMessage(BaseModel):
     parts: List[MessagePart] = Field(
         description="List of message parts that make up the message content."
     )
-    name: str = omittable_field(
+    name: str | MISSING = omittable_field(
         description="The name of the participant."
     )
 
@@ -424,16 +428,20 @@ class FunctionToolDefinition(GenericToolDefinition):
     """
 
     type: Literal["function"] = Field(description="The type of the tool.")
-    description: str = omittable_field(
+    description: str | None | MISSING = omittable_field(
         description=(
             "The description of the tool. "
+            "Omit when it is not captured; record null when the provider reports "
+            "that the tool has no description. "
             "Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. "
             "Instrumentations MAY provide a way to enable populating this property."
         ),
     )
-    parameters: JsonSchemaDraft7Dict = omittable_field(
+    parameters: JsonSchemaDraft7Dict | None | MISSING = omittable_field(
         description=(
             "JSON Schema document describing the parameters accepted by the tool. "
+            "Omit when it is not captured; record null when the provider reports "
+            "that the tool has no parameters. "
             "The value MUST conform to JSON Schema draft-07. "
             "Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. "
             "Instrumentations MAY provide a way to enable populating this property."
@@ -469,10 +477,10 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str = omittable_field(
+    id: str | MISSING = omittable_field(
         description="A unique identifier for the document."
     )
-    score: float = omittable_field(
+    score: float | MISSING = omittable_field(
         description="The relevance score of the document."
     )
 
@@ -499,14 +507,16 @@ class MemoryRecord(BaseModel):
     Represents a single memory record stored in or retrieved from a memory store.
     """
 
-    content: Any = Field(description="The content of the memory record.")
-    id: str = omittable_field(
+    content: Any = Field(
+        description="The content of the memory record. Null represents a captured null value."
+    )
+    id: str | MISSING = omittable_field(
         description="A unique identifier for the memory record."
     )
-    metadata: dict[str, Any] = omittable_field(
+    metadata: dict[str, Any] | MISSING = omittable_field(
         description="Provider-specific metadata associated with the memory record.",
     )
-    score: float = omittable_field(
+    score: float | MISSING = omittable_field(
         description="The relevance score of the memory record when populated on search results.",
     )
 

--- a/docs/gen-ai/non-normative/models.py
+++ b/docs/gen-ai/non-normative/models.py
@@ -24,7 +24,7 @@ import argparse
 import json
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Union
 
 from pydantic import (
     BaseModel,
@@ -63,7 +63,7 @@ class ToolCallRequestPart(BaseModel):
     type: Literal["tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: Optional[str] = Field(
+    id: str = Field(
         default=None, description="Unique identifier for the tool call."
     )
     name: str = Field(description="Name of the tool.")
@@ -80,7 +80,7 @@ class ToolCallResponsePart(BaseModel):
     type: Literal["tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: Optional[str] = Field(default=None, description="Unique tool call identifier.")
+    id: str = Field(default=None, description="Unique tool call identifier.")
     response: Any = Field(description="Tool call response.")
 
     model_config = ConfigDict(extra="allow")
@@ -122,7 +122,7 @@ class ServerToolCallPart(BaseModel):
     type: Literal["server_tool_call"] = Field(
         description="The type of the content captured in this part."
     )
-    id: Optional[str] = Field(
+    id: str = Field(
         default=None, description="Unique identifier for the server tool call."
     )
     name: str = Field(description="Name of the server tool.")
@@ -139,7 +139,7 @@ class ServerToolCallResponsePart(BaseModel):
     type: Literal["server_tool_call_response"] = Field(
         description="The type of the content captured in this part."
     )
-    id: Optional[str] = Field(
+    id: str = Field(
         default=None,
         description="Unique server tool call identifier matching the original call.",
     )
@@ -180,11 +180,11 @@ class CompactionPart(BaseModel):
     type: Literal["compaction"] = Field(
         description="The type of the content captured in this part."
     )
-    id: Optional[str] = Field(
+    id: str = Field(
         default=None,
         description="Provider-assigned identifier for the compaction item or block.",
     )
-    content: Optional[str] = Field(
+    content: str = Field(
         default=None,
         description="The unencrypted compacted conversation summary, when available.",
     )
@@ -198,7 +198,7 @@ class BlobPart(BaseModel):
     type: Literal["blob"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: Optional[str] = Field(
+    mime_type: str = Field(
         default=None, description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -215,7 +215,7 @@ class FilePart(BaseModel):
     type: Literal["file"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: Optional[str] = Field(
+    mime_type: str = Field(
         default=None, description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -234,7 +234,7 @@ class UriPart(BaseModel):
     type: Literal["uri"] = Field(
         description="The type of the content captured in this part."
     )
-    mime_type: Optional[str] = Field(
+    mime_type: str = Field(
         default=None, description="The IANA MIME type of the attached data."
     )
     modality: Union[Modality, str] = Field(
@@ -304,7 +304,7 @@ class ChatMessage(BaseModel):
     parts: List[MessagePart] = Field(
         description="List of message parts that make up the message content."
     )
-    name: Optional[str] = Field(
+    name: str = Field(
         default=None, description="The name of the participant."
     )
 
@@ -417,7 +417,7 @@ class FunctionToolDefinition(GenericToolDefinition):
     """
 
     type: Literal["function"] = Field(description="The type of the tool.")
-    description: Optional[str] = Field(
+    description: str = Field(
         default=None,
         description=(
             "The description of the tool. "
@@ -425,7 +425,7 @@ class FunctionToolDefinition(GenericToolDefinition):
             "Instrumentations MAY provide a way to enable populating this property."
         ),
     )
-    parameters: Optional[JsonSchemaDraft7Dict] = Field(
+    parameters: JsonSchemaDraft7Dict = Field(
         default=None,
         description=(
             "JSON Schema document describing the parameters accepted by the tool. "
@@ -464,10 +464,10 @@ class RetrievalDocument(BaseModel):
     Represents a single document retrieved from a vector database or search system.
     """
 
-    id: str | None = Field(
+    id: str = Field(
         default=None, description="A unique identifier for the document."
     )
-    score: float | None = Field(
+    score: float = Field(
         default=None, description="The relevance score of the document."
     )
 
@@ -495,14 +495,14 @@ class MemoryRecord(BaseModel):
     """
 
     content: Any = Field(description="The content of the memory record.")
-    id: Optional[str] = Field(
+    id: str = Field(
         default=None, description="A unique identifier for the memory record."
     )
-    metadata: Optional[dict[str, Any]] = Field(
+    metadata: dict[str, Any] = Field(
         default=None,
         description="Provider-specific metadata associated with the memory record.",
     )
-    score: Optional[float] = Field(
+    score: float = Field(
         default=None,
         description="The relevance score of the memory record when populated on search results.",
     )

--- a/model/gen-ai/gen-ai-input-messages.json
+++ b/model/gen-ai/gen-ai-input-messages.json
@@ -374,7 +374,7 @@
                     "type": "string"
                 },
                 "arguments": {
-                    "description": "Arguments for the tool call.",
+                    "description": "Arguments for the tool call. Omit when they are not captured; record null when the call has null arguments.",
                     "title": "Arguments"
                 }
             },
@@ -401,7 +401,7 @@
                     "type": "string"
                 },
                 "response": {
-                    "description": "Tool call response.",
+                    "description": "Tool call response. Null represents a captured null response.",
                     "title": "Response"
                 }
             },

--- a/model/gen-ai/gen-ai-input-messages.json
+++ b/model/gen-ai/gen-ai-input-messages.json
@@ -10,7 +10,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"
@@ -100,7 +99,6 @@
                     "type": "array"
                 },
                 "name": {
-                    "default": null,
                     "description": "The name of the participant.",
                     "title": "Name",
                     "type": "string"
@@ -124,13 +122,11 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Provider-assigned identifier for the compaction item or block.",
                     "title": "Id",
                     "type": "string"
                 },
                 "content": {
-                    "default": null,
                     "description": "The unencrypted compacted conversation summary, when available.",
                     "title": "Content",
                     "type": "string"
@@ -153,7 +149,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"
@@ -286,7 +281,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique identifier for the server tool call.",
                     "title": "Id",
                     "type": "string"
@@ -320,7 +314,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique server tool call identifier matching the original call.",
                     "title": "Id",
                     "type": "string"
@@ -371,7 +364,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique identifier for the tool call.",
                     "title": "Id",
                     "type": "string"
@@ -382,7 +374,6 @@
                     "type": "string"
                 },
                 "arguments": {
-                    "default": null,
                     "description": "Arguments for the tool call.",
                     "title": "Arguments"
                 }
@@ -405,7 +396,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique tool call identifier.",
                     "title": "Id",
                     "type": "string"
@@ -433,7 +423,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"

--- a/model/gen-ai/gen-ai-input-messages.json
+++ b/model/gen-ai/gen-ai-input-messages.json
@@ -10,17 +10,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [
@@ -107,17 +100,10 @@
                     "type": "array"
                 },
                 "name": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The name of the participant.",
-                    "title": "Name"
+                    "title": "Name",
+                    "type": "string"
                 }
             },
             "required": [
@@ -138,30 +124,16 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Provider-assigned identifier for the compaction item or block.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "content": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The unencrypted compacted conversation summary, when available.",
-                    "title": "Content"
+                    "title": "Content",
+                    "type": "string"
                 }
             },
             "required": [
@@ -181,17 +153,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [
@@ -321,17 +286,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique identifier for the server tool call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "name": {
                     "description": "Name of the server tool.",
@@ -362,17 +320,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique server tool call identifier matching the original call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "server_tool_call_response": {
                     "$ref": "#/$defs/GenericServerToolCallResponse",
@@ -420,17 +371,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique identifier for the tool call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "name": {
                     "description": "Name of the tool.",
@@ -461,17 +405,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique tool call identifier.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "response": {
                     "description": "Tool call response.",
@@ -496,17 +433,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [

--- a/model/gen-ai/gen-ai-memory-records.json
+++ b/model/gen-ai/gen-ai-memory-records.json
@@ -9,44 +9,23 @@
                     "title": "Content"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "A unique identifier for the memory record.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "metadata": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": true,
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
+                    "additionalProperties": true,
                     "default": null,
                     "description": "Provider-specific metadata associated with the memory record.",
-                    "title": "Metadata"
+                    "title": "Metadata",
+                    "type": "object"
                 },
                 "score": {
-                    "anyOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The relevance score of the memory record when populated on search results.",
-                    "title": "Score"
+                    "title": "Score",
+                    "type": "number"
                 }
             },
             "required": [

--- a/model/gen-ai/gen-ai-memory-records.json
+++ b/model/gen-ai/gen-ai-memory-records.json
@@ -9,20 +9,17 @@
                     "title": "Content"
                 },
                 "id": {
-                    "default": null,
                     "description": "A unique identifier for the memory record.",
                     "title": "Id",
                     "type": "string"
                 },
                 "metadata": {
                     "additionalProperties": true,
-                    "default": null,
                     "description": "Provider-specific metadata associated with the memory record.",
                     "title": "Metadata",
                     "type": "object"
                 },
                 "score": {
-                    "default": null,
                     "description": "The relevance score of the memory record when populated on search results.",
                     "title": "Score",
                     "type": "number"

--- a/model/gen-ai/gen-ai-memory-records.json
+++ b/model/gen-ai/gen-ai-memory-records.json
@@ -5,7 +5,7 @@
             "description": "Represents a single memory record stored in or retrieved from a memory store.",
             "properties": {
                 "content": {
-                    "description": "The content of the memory record.",
+                    "description": "The content of the memory record. Null represents a captured null value.",
                     "title": "Content"
                 },
                 "id": {

--- a/model/gen-ai/gen-ai-output-messages.json
+++ b/model/gen-ai/gen-ai-output-messages.json
@@ -10,7 +10,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"
@@ -53,13 +52,11 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Provider-assigned identifier for the compaction item or block.",
                     "title": "Id",
                     "type": "string"
                 },
                 "content": {
-                    "default": null,
                     "description": "The unencrypted compacted conversation summary, when available.",
                     "title": "Content",
                     "type": "string"
@@ -82,7 +79,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"
@@ -243,7 +239,6 @@
                     "type": "array"
                 },
                 "name": {
-                    "default": null,
                     "description": "The name of the participant.",
                     "title": "Name",
                     "type": "string"
@@ -313,7 +308,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique identifier for the server tool call.",
                     "title": "Id",
                     "type": "string"
@@ -347,7 +341,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique server tool call identifier matching the original call.",
                     "title": "Id",
                     "type": "string"
@@ -398,7 +391,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique identifier for the tool call.",
                     "title": "Id",
                     "type": "string"
@@ -409,7 +401,6 @@
                     "type": "string"
                 },
                 "arguments": {
-                    "default": null,
                     "description": "Arguments for the tool call.",
                     "title": "Arguments"
                 }
@@ -432,7 +423,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "default": null,
                     "description": "Unique tool call identifier.",
                     "title": "Id",
                     "type": "string"
@@ -460,7 +450,6 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "default": null,
                     "description": "The IANA MIME type of the attached data.",
                     "title": "Mime Type",
                     "type": "string"

--- a/model/gen-ai/gen-ai-output-messages.json
+++ b/model/gen-ai/gen-ai-output-messages.json
@@ -401,7 +401,7 @@
                     "type": "string"
                 },
                 "arguments": {
-                    "description": "Arguments for the tool call.",
+                    "description": "Arguments for the tool call. Omit when they are not captured; record null when the call has null arguments.",
                     "title": "Arguments"
                 }
             },
@@ -428,7 +428,7 @@
                     "type": "string"
                 },
                 "response": {
-                    "description": "Tool call response.",
+                    "description": "Tool call response. Null represents a captured null response.",
                     "title": "Response"
                 }
             },

--- a/model/gen-ai/gen-ai-output-messages.json
+++ b/model/gen-ai/gen-ai-output-messages.json
@@ -10,17 +10,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [
@@ -60,30 +53,16 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Provider-assigned identifier for the compaction item or block.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "content": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The unencrypted compacted conversation summary, when available.",
-                    "title": "Content"
+                    "title": "Content",
+                    "type": "string"
                 }
             },
             "required": [
@@ -103,17 +82,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [
@@ -271,17 +243,10 @@
                     "type": "array"
                 },
                 "name": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The name of the participant.",
-                    "title": "Name"
+                    "title": "Name",
+                    "type": "string"
                 },
                 "finish_reason": {
                     "anyOf": [
@@ -348,17 +313,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique identifier for the server tool call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "name": {
                     "description": "Name of the server tool.",
@@ -389,17 +347,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique server tool call identifier matching the original call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "server_tool_call_response": {
                     "$ref": "#/$defs/GenericServerToolCallResponse",
@@ -447,17 +398,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique identifier for the tool call.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "name": {
                     "description": "Name of the tool.",
@@ -488,17 +432,10 @@
                     "type": "string"
                 },
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "Unique tool call identifier.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "response": {
                     "description": "Tool call response.",
@@ -523,17 +460,10 @@
                     "type": "string"
                 },
                 "mime_type": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The IANA MIME type of the attached data.",
-                    "title": "Mime Type"
+                    "title": "Mime Type",
+                    "type": "string"
                 },
                 "modality": {
                     "anyOf": [

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,13 +5,11 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
-                    "default": null,
                     "description": "A unique identifier for the document.",
                     "title": "Id",
                     "type": "string"
                 },
                 "score": {
-                    "default": null,
                     "description": "The relevance score of the document.",
                     "title": "Score",
                     "type": "number"

--- a/model/gen-ai/gen-ai-retrieval-documents.json
+++ b/model/gen-ai/gen-ai-retrieval-documents.json
@@ -5,30 +5,16 @@
             "description": "Represents a single document retrieved from a vector database or search system.",
             "properties": {
                 "id": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "A unique identifier for the document.",
-                    "title": "Id"
+                    "title": "Id",
+                    "type": "string"
                 },
                 "score": {
-                    "anyOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The relevance score of the document.",
-                    "title": "Score"
+                    "title": "Score",
+                    "type": "number"
                 }
             },
             "title": "RetrievalDocument",

--- a/model/gen-ai/gen-ai-tool-definitions.json
+++ b/model/gen-ai/gen-ai-tool-definitions.json
@@ -16,25 +16,15 @@
                     "type": "string"
                 },
                 "description": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "default": null,
                     "description": "The description of the tool. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
-                    "title": "Description"
+                    "title": "Description",
+                    "type": "string"
                 },
                 "parameters": {
                     "anyOf": [
                         {
                             "$ref": "http://json-schema.org/draft-07/schema#"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "default": null,

--- a/model/gen-ai/gen-ai-tool-definitions.json
+++ b/model/gen-ai/gen-ai-tool-definitions.json
@@ -16,7 +16,6 @@
                     "type": "string"
                 },
                 "description": {
-                    "default": null,
                     "description": "The description of the tool. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
                     "title": "Description",
                     "type": "string"
@@ -27,7 +26,6 @@
                             "$ref": "http://json-schema.org/draft-07/schema#"
                         }
                     ],
-                    "default": null,
                     "description": "JSON Schema document describing the parameters accepted by the tool. The value MUST conform to JSON Schema draft-07. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
                     "title": "Parameters"
                 }

--- a/model/gen-ai/gen-ai-tool-definitions.json
+++ b/model/gen-ai/gen-ai-tool-definitions.json
@@ -16,17 +16,27 @@
                     "type": "string"
                 },
                 "description": {
-                    "description": "The description of the tool. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
-                    "title": "Description",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The description of the tool. Omit when it is not captured; record null when the provider reports that the tool has no description. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
+                    "title": "Description"
                 },
                 "parameters": {
                     "anyOf": [
                         {
                             "$ref": "http://json-schema.org/draft-07/schema#"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
-                    "description": "JSON Schema document describing the parameters accepted by the tool. The value MUST conform to JSON Schema draft-07. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
+                    "description": "JSON Schema document describing the parameters accepted by the tool. Omit when it is not captured; record null when the provider reports that the tool has no parameters. The value MUST conform to JSON Schema draft-07. Since this attribute could be large, it's NOT RECOMMENDED to be populated by default. Instrumentations MAY provide a way to enable populating this property.",
                     "title": "Parameters"
                 }
             },


### PR DESCRIPTION
## Motivation

Generated GenAI JSON schemas currently accept both a missing optional field and an explicit `null`. Consumers cannot distinguish omission from an explicit null value.

## Changes

- Keep optional fields optional while making their declared JSON type non-nullable.
- Regenerate the input/output message, tool-definition, retrieval-document, and memory-record schemas.
- Add a bugfix changelog fragment.

## Validation

- `make generate-all`
- `make check-policies`
- Verified an omitted tool-call `id` is accepted.
- Verified an explicit null tool-call `id` is rejected.

Fixes #53