### PR TITLE
feat(gen-ai): add semantic conventions for AI agent action gate and cryptographic ledgers

### DIFF
--- a/docs/gen-ai/agent-action-gate.md
+++ b/docs/gen-ai/agent-action-gate.md
@@ -1,0 +1,36 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Agent Action Gate & Ledger
+--->
+
+# Semantic Conventions for AI Agent Action Gate & Cryptographic Ledgers
+
+**Status**: [Development][DocumentStatus]
+
+This document defines semantic conventions for recording **Gate/Prove runtime safety evaluations, tool tiers, simulation modes, and cryptographic action ledgers** in AI Agent spans.
+
+---
+
+## Zero-Trust Agent Execution Conventions
+
+When an autonomous agent invokes tools with potential side-effects (e.g., executing commands, modifying databases, provisioning cloud resources), spans MUST capture the deterministic policy evaluation and audit receipt.
+
+### Attributes
+
+| Attribute | Type | Description | Examples |
+|---|---|---|---|
+| `gen_ai.agent.tool.disposition` | string (enum) | Operational decision disposition | `allow`, `simulate`, `deny` |
+| `gen_ai.agent.tool.tier` | string (enum) | Tool sensitivity tier | `read`, `write`, `destructive`, `provision`, `decommission` |
+| `gen_ai.agent.tool.never_equate_intent_to_approval` | boolean | Policy invariant flag | `true` |
+| `gen_ai.agent.action_ledger.receipt_hash` | string | SHA-256 hash of the append-only ledger entry | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
+| `gen_ai.agent.kill_switch_engaged` | boolean | Whether an atomic kill-switch was active | `false` |
+
+---
+
+## Compliance Crosswalk
+
+These attributes map directly to international AI governance and security frameworks:
+- **ISO 42001 (A.6.2):** Continuous validation and authorization of AI decisions.
+- **NIST AI RMF (GOVERN-1.2 & MANAGE-2.4):** Human-in-the-loop oversight and fail-safe mechanisms for autonomous actions.
+- **SOC 2 Type II (CC6.8):** Immutable audit trails for automated configuration changes.
+
+[DocumentStatus]: https://opentelemetry.io/docs/specs/otel/document-status

--- a/docs/registry/attributes/gen-ai.md
+++ b/docs/registry/attributes/gen-ai.md
@@ -7,9 +7,14 @@
 
 | Key | Stability | Value Type | Description | Example Values |
 | --- | --- | --- | --- | --- |
+| <a id="gen-ai-agent-action-ledger-receipt-hash" href="#gen-ai-agent-action-ledger-receipt-hash">`gen_ai.agent.action_ledger.receipt_hash`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Cryptographic SHA-256 hash chaining this tool execution into an immutable action ledger. | |
 | <a id="gen-ai-agent-description" href="#gen-ai-agent-description">`gen_ai.agent.description`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Free-form description of the GenAI agent provided by the application. | `Helps with math problems`; `Generates fiction stories` |
 | <a id="gen-ai-agent-id" href="#gen-ai-agent-id">`gen_ai.agent.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The unique and stable identifier of the GenAI hosted agent resource. [1] | `asst_5j66UpCpwteGg4YSxUnt7lPY`; `arn:aws:bedrock:us-east-1:123:agent/42`; `urn:agent:projects-123:projects:123:locations:us-east1:aiplatform:reasoningEngines:456` |
+| <a id="gen-ai-agent-kill-switch-engaged" href="#gen-ai-agent-kill-switch-engaged">`gen_ai.agent.kill_switch_engaged`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Flag indicating whether an atomic kill-switch was active during tool evaluation. | |
 | <a id="gen-ai-agent-name" href="#gen-ai-agent-name">`gen_ai.agent.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Human-readable name of the GenAI agent provided by the application. | `Math Tutor`; `Fiction Writer` |
+| <a id="gen-ai-agent-tool-disposition" href="#gen-ai-agent-tool-disposition">`gen_ai.agent.tool.disposition`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The operational decision disposition for an agent tool execution. | `allow`; `simulate`; `deny` |
+| <a id="gen-ai-agent-tool-never-equate-intent-to-approval" href="#gen-ai-agent-tool-never-equate-intent-to-approval">`gen_ai.agent.tool.never_equate_intent_to_approval`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Policy invariant flag verifying model confidence was not equated to execution authorization. | |
+| <a id="gen-ai-agent-tool-tier" href="#gen-ai-agent-tool-tier">`gen_ai.agent.tool.tier`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The sensitivity tier assigned to the agent tool. | `read`; `write`; `destructive` |
 | <a id="gen-ai-agent-version" href="#gen-ai-agent-version">`gen_ai.agent.version`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The version of the GenAI agent. | `1.0.0`; `2025-05-01` |
 | <a id="gen-ai-conversation-compacted" href="#gen-ai-conversation-compacted">`gen_ai.conversation.compacted`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | Indicates whether the effective conversation context used for this operation is a compacted view of a prior conversation. [2] | `true` |
 | <a id="gen-ai-conversation-id" href="#gen-ai-conversation-id">`gen_ai.conversation.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation. [3] | `conv_5j66UpCpwteGg4YSxUnt7lPY` |
@@ -334,6 +339,28 @@ available for a given framework, this attribute MUST NOT be captured by default.
 
 Semantic conventions for individual Generative AI frameworks SHOULD document
 what `gen_ai.workflow.name` means in the context of that framework.
+
+---
+
+`gen_ai.agent.tool.disposition` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value | Description | Stability |
+| --- | --- | --- |
+| `allow` | The tool invocation was permitted and executed. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `deny` | The tool invocation was rejected by the Gate/Prove policy. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `simulate` | The tool invocation was executed in safe, non-destructive simulation mode. | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`gen_ai.agent.tool.tier` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value | Description | Stability |
+| --- | --- | --- |
+| `decommission` | Infrastructure/resource teardown tool. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `destructive` | High-blast operation requiring explicit human-in-the-loop prove token. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `provision` | Infrastructure/resource provisioning tool. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `read` | Safe, non-mutating inspection or retrieval tool. | ![Development](https://img.shields.io/badge/-development-blue) |
+| `write` | State-mutating tool (defaults to simulation if unapproved). | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/model/gen-ai/action-gate.yaml
+++ b/model/gen-ai/action-gate.yaml
@@ -1,0 +1,60 @@
+file_format: definition/2
+attributes:
+  - key: gen_ai.agent.tool.disposition
+    type:
+      members:
+        - id: allow
+          stability: development
+          value: "allow"
+          brief: "The tool invocation was permitted and executed."
+        - id: simulate
+          stability: development
+          value: "simulate"
+          brief: "The tool invocation was executed in safe, non-destructive simulation mode."
+        - id: deny
+          stability: development
+          value: "deny"
+          brief: "The tool invocation was rejected by the Gate/Prove policy."
+    stability: development
+    brief: "The operational decision disposition for an agent tool execution."
+
+  - key: gen_ai.agent.tool.tier
+    type:
+      members:
+        - id: read
+          stability: development
+          value: "read"
+          brief: "Safe, non-mutating inspection or retrieval tool."
+        - id: write
+          stability: development
+          value: "write"
+          brief: "State-mutating tool (defaults to simulation if unapproved)."
+        - id: destructive
+          stability: development
+          value: "destructive"
+          brief: "High-blast operation requiring explicit human-in-the-loop prove token."
+        - id: provision
+          stability: development
+          value: "provision"
+          brief: "Infrastructure/resource provisioning tool."
+        - id: decommission
+          stability: development
+          value: "decommission"
+          brief: "Infrastructure/resource teardown tool."
+    stability: development
+    brief: "The sensitivity tier assigned to the agent tool."
+
+  - key: gen_ai.agent.tool.never_equate_intent_to_approval
+    type: boolean
+    stability: development
+    brief: "Policy invariant flag verifying model confidence was not equated to execution authorization."
+
+  - key: gen_ai.agent.action_ledger.receipt_hash
+    type: string
+    stability: development
+    brief: "Cryptographic SHA-256 hash chaining this tool execution into an immutable action ledger."
+
+  - key: gen_ai.agent.kill_switch_engaged
+    type: boolean
+    stability: development
+    brief: "Flag indicating whether an atomic kill-switch was active during tool evaluation."


### PR DESCRIPTION
### Summary
Defines standard OpenTelemetry Semantic Conventions for AI Agent Tool Execution Policy (`gen_ai.agent.tool.*`) and Cryptographic Action Ledgers (`gen_ai.agent.action_ledger.*`), providing standardized telemetry attributes for zero-trust runtime policy and audit compliance.

### Problem Solved
As autonomous AI agents execute tool calls with real-world side-effects (file writes, bash commands, cloud resource modifications), observability platforms currently lack standardized semantic conventions to record:
1. Whether an invocation was evaluated by a deterministic Gate/Prove policy boundary (`gen_ai.agent.tool.disposition`: `allow` | `simulate` | `deny`).
2. The sensitivity tier of the tool (`gen_ai.agent.tool.tier`: `read` | `write` | `destructive` | `provision` | `decommission`).
3. Verification that model confidence was not equated to execution authorization (`gen_ai.agent.tool.never_equate_intent_to_approval: true`).
4. Cryptographic SHA-256 hash-chaining for immutable audit readiness (`gen_ai.agent.action_ledger.receipt_hash`).
5. Real-time atomic kill-switch engagement (`gen_ai.agent.kill_switch_engaged`).

### Testing & Validation
- Validated YAML schema definition against OpenTelemetry semantic convention definition/2 specification.
- Added comprehensive documentation and crosswalk mapping to ISO 42001 (A.6.2), NIST AI RMF (GOVERN-1.2), and SOC 2 Type II (CC6.8).
