### PR TITLE
Clarify MCP HTTP error types

### DIFF
--- a/changelog.d/+.clarification.2.md
+++ b/changelog.d/+.clarification.2.md
@@ -1,0 +1,1 @@
+Clarify how MCP instrumentation records HTTP failures without JSON-RPC error codes.

--- a/docs/gen-ai/mcp.md
+++ b/docs/gen-ai/mcp.md
@@ -181,9 +181,9 @@ to avoid high cardinality span names.
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
-`http.response.status_code` SHOULD be recorded according to the HTTP semantic
-conventions and `error.type` SHOULD be set to the string representation of the
-HTTP status code. Otherwise
+`error.type` SHOULD be set to the string representation of the HTTP status
+code. Separately enabled HTTP instrumentation records
+`http.response.status_code` according to the HTTP semantic conventions. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -411,9 +411,9 @@ to avoid high cardinality span names.
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
-`http.response.status_code` SHOULD be recorded according to the HTTP semantic
-conventions and `error.type` SHOULD be set to the string representation of the
-HTTP status code. Otherwise
+`error.type` SHOULD be set to the string representation of the HTTP status
+code. Separately enabled HTTP instrumentation records
+`http.response.status_code` according to the HTTP semantic conventions. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -633,9 +633,9 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
-`http.response.status_code` SHOULD be recorded according to the HTTP semantic
-conventions and `error.type` SHOULD be set to the string representation of the
-HTTP status code. Otherwise
+`error.type` SHOULD be set to the string representation of the HTTP status
+code. Separately enabled HTTP instrumentation records
+`http.response.status_code` according to the HTTP semantic conventions. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -804,9 +804,9 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
-`http.response.status_code` SHOULD be recorded according to the HTTP semantic
-conventions and `error.type` SHOULD be set to the string representation of the
-HTTP status code. Otherwise
+`error.type` SHOULD be set to the string representation of the HTTP status
+code. Separately enabled HTTP instrumentation records
+`http.response.status_code` according to the HTTP semantic conventions. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.

--- a/docs/gen-ai/mcp.md
+++ b/docs/gen-ai/mcp.md
@@ -179,8 +179,10 @@ to avoid high cardinality span names.
 
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
-`rpc.response.status_code` for which codes classify as errors. Otherwise
-(for example on timeouts or transport errors) it SHOULD be set following the
+`rpc.response.status_code` for which codes classify as errors. When an HTTP
+response rejects the operation without a JSON-RPC error code, `error.type`
+SHOULD be set to the string representation of the HTTP status code. Otherwise
+(for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
 
@@ -405,8 +407,10 @@ to avoid high cardinality span names.
 
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
-`rpc.response.status_code` for which codes classify as errors. Otherwise
-(for example on timeouts or transport errors) it SHOULD be set following the
+`rpc.response.status_code` for which codes classify as errors. When an HTTP
+response rejects the operation without a JSON-RPC error code, `error.type`
+SHOULD be set to the string representation of the HTTP status code. Otherwise
+(for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
 
@@ -623,8 +627,10 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
-`rpc.response.status_code` for which codes classify as errors. Otherwise
-(for example on timeouts or transport errors) it SHOULD be set following the
+`rpc.response.status_code` for which codes classify as errors. When an HTTP
+response rejects the operation without a JSON-RPC error code, `error.type`
+SHOULD be set to the string representation of the HTTP status code. Otherwise
+(for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
 
@@ -790,8 +796,10 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
-`rpc.response.status_code` for which codes classify as errors. Otherwise
-(for example on timeouts or transport errors) it SHOULD be set following the
+`rpc.response.status_code` for which codes classify as errors. When an HTTP
+response rejects the operation without a JSON-RPC error code, `error.type`
+SHOULD be set to the string representation of the HTTP status code. Otherwise
+(for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
 

--- a/docs/gen-ai/mcp.md
+++ b/docs/gen-ai/mcp.md
@@ -182,11 +182,8 @@ to avoid high cardinality span names.
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
 `error.type` SHOULD be set to the string representation of the HTTP status
-code. Separately enabled HTTP instrumentation records
-`http.response.status_code` according to the HTTP semantic conventions. Otherwise
-(for example on timeouts or other transport errors) it SHOULD be set following the
-[`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
-guidance.
+code. Otherwise (for example on timeouts or other transport errors), it SHOULD be
+set to the canonical name of the exception or error that occurred.
 
 When JSON-RPC call is successful, but an error is returned within the
 result payload, this attribute SHOULD be set to the low-cardinality
@@ -412,11 +409,8 @@ to avoid high cardinality span names.
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
 `error.type` SHOULD be set to the string representation of the HTTP status
-code. Separately enabled HTTP instrumentation records
-`http.response.status_code` according to the HTTP semantic conventions. Otherwise
-(for example on timeouts or other transport errors) it SHOULD be set following the
-[`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
-guidance.
+code. Otherwise (for example on timeouts or other transport errors), it SHOULD be
+set to the canonical name of the exception or error that occurred.
 
 When JSON-RPC call is successful, but an error is returned within the
 result payload, this attribute SHOULD be set to the low-cardinality
@@ -634,11 +628,8 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
 `error.type` SHOULD be set to the string representation of the HTTP status
-code. Separately enabled HTTP instrumentation records
-`http.response.status_code` according to the HTTP semantic conventions. Otherwise
-(for example on timeouts or other transport errors) it SHOULD be set following the
-[`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
-guidance.
+code. Otherwise (for example on timeouts or other transport errors), it SHOULD be
+set to the canonical name of the exception or error that occurred.
 
 When JSON-RPC call is successful, but an error is returned within the
 result payload, this attribute SHOULD be set to the low-cardinality
@@ -805,11 +796,8 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
 response ends the operation in error without a JSON-RPC error code,
 `error.type` SHOULD be set to the string representation of the HTTP status
-code. Separately enabled HTTP instrumentation records
-`http.response.status_code` according to the HTTP semantic conventions. Otherwise
-(for example on timeouts or other transport errors) it SHOULD be set following the
-[`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
-guidance.
+code. Otherwise (for example on timeouts or other transport errors), it SHOULD be
+set to the canonical name of the exception or error that occurred.
 
 When JSON-RPC call is successful, but an error is returned within the
 result payload, this attribute SHOULD be set to the low-cardinality

--- a/docs/gen-ai/mcp.md
+++ b/docs/gen-ai/mcp.md
@@ -180,8 +180,10 @@ to avoid high cardinality span names.
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
-response rejects the operation without a JSON-RPC error code, `error.type`
-SHOULD be set to the string representation of the HTTP status code. Otherwise
+response ends the operation in error without a JSON-RPC error code,
+`http.response.status_code` SHOULD be recorded according to the HTTP semantic
+conventions and `error.type` SHOULD be set to the string representation of the
+HTTP status code. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -408,8 +410,10 @@ to avoid high cardinality span names.
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
-response rejects the operation without a JSON-RPC error code, `error.type`
-SHOULD be set to the string representation of the HTTP status code. Otherwise
+response ends the operation in error without a JSON-RPC error code,
+`http.response.status_code` SHOULD be recorded according to the HTTP semantic
+conventions and `error.type` SHOULD be set to the string representation of the
+HTTP status code. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -628,8 +632,10 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
-response rejects the operation without a JSON-RPC error code, `error.type`
-SHOULD be set to the string representation of the HTTP status code. Otherwise
+response ends the operation in error without a JSON-RPC error code,
+`http.response.status_code` SHOULD be recorded according to the HTTP semantic
+conventions and `error.type` SHOULD be set to the string representation of the
+HTTP status code. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.
@@ -797,8 +803,10 @@ of `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
 **[1] `error.type`:** When the response carries a JSON-RPC error code that classifies as an error,
 `error.type` SHOULD be set to the string representation of that code. See
 `rpc.response.status_code` for which codes classify as errors. When an HTTP
-response rejects the operation without a JSON-RPC error code, `error.type`
-SHOULD be set to the string representation of the HTTP status code. Otherwise
+response ends the operation in error without a JSON-RPC error code,
+`http.response.status_code` SHOULD be recorded according to the HTTP semantic
+conventions and `error.type` SHOULD be set to the string representation of the
+HTTP status code. Otherwise
 (for example on timeouts or other transport errors) it SHOULD be set following the
 [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
 guidance.

--- a/model/mcp/common.yaml
+++ b/model/mcp/common.yaml
@@ -30,8 +30,10 @@ attribute_groups:
         note: |
           When the response carries a JSON-RPC error code that classifies as an error,
           `error.type` SHOULD be set to the string representation of that code. See
-          `rpc.response.status_code` for which codes classify as errors. Otherwise
-          (for example on timeouts or transport errors) it SHOULD be set following the
+          `rpc.response.status_code` for which codes classify as errors. When an HTTP
+          response rejects the operation without a JSON-RPC error code, `error.type`
+          SHOULD be set to the string representation of the HTTP status code. Otherwise
+          (for example on timeouts or other transport errors) it SHOULD be set following the
           [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
           guidance.
 

--- a/model/mcp/common.yaml
+++ b/model/mcp/common.yaml
@@ -31,8 +31,10 @@ attribute_groups:
           When the response carries a JSON-RPC error code that classifies as an error,
           `error.type` SHOULD be set to the string representation of that code. See
           `rpc.response.status_code` for which codes classify as errors. When an HTTP
-          response rejects the operation without a JSON-RPC error code, `error.type`
-          SHOULD be set to the string representation of the HTTP status code. Otherwise
+          response ends the operation in error without a JSON-RPC error code,
+          `http.response.status_code` SHOULD be recorded according to the HTTP semantic
+          conventions and `error.type` SHOULD be set to the string representation of the
+          HTTP status code. Otherwise
           (for example on timeouts or other transport errors) it SHOULD be set following the
           [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
           guidance.

--- a/model/mcp/common.yaml
+++ b/model/mcp/common.yaml
@@ -33,11 +33,8 @@ attribute_groups:
           `rpc.response.status_code` for which codes classify as errors. When an HTTP
           response ends the operation in error without a JSON-RPC error code,
           `error.type` SHOULD be set to the string representation of the HTTP status
-          code. Separately enabled HTTP instrumentation records
-          `http.response.status_code` according to the HTTP semantic conventions. Otherwise
-          (for example on timeouts or other transport errors) it SHOULD be set following the
-          [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
-          guidance.
+          code. Otherwise (for example on timeouts or other transport errors), it SHOULD be
+          set to the canonical name of the exception or error that occurred.
 
           When JSON-RPC call is successful, but an error is returned within the
           result payload, this attribute SHOULD be set to the low-cardinality

--- a/model/mcp/common.yaml
+++ b/model/mcp/common.yaml
@@ -32,9 +32,9 @@ attribute_groups:
           `error.type` SHOULD be set to the string representation of that code. See
           `rpc.response.status_code` for which codes classify as errors. When an HTTP
           response ends the operation in error without a JSON-RPC error code,
-          `http.response.status_code` SHOULD be recorded according to the HTTP semantic
-          conventions and `error.type` SHOULD be set to the string representation of the
-          HTTP status code. Otherwise
+          `error.type` SHOULD be set to the string representation of the HTTP status
+          code. Separately enabled HTTP instrumentation records
+          `http.response.status_code` according to the HTTP semantic conventions. Otherwise
           (for example on timeouts or other transport errors) it SHOULD be set following the
           [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/error.md)
           guidance.


### PR DESCRIPTION
## Summary

Clarifies `error.type` for MCP operations rejected by HTTP before a JSON-RPC error response is available.

- records the HTTP status code as `error.type` for HTTP-only failures
- retains the existing JSON-RPC and transport-error guidance
- regenerates MCP documentation

Fixes #312.

## Validation

- `make generate-all`
- `make check-policies`