### PR TITLE
Update conformance runner to record findings in data files

### DIFF
--- a/reference/scenarios/agent-framework/data.json
+++ b/reference/scenarios/agent-framework/data.json
@@ -65,5 +65,169 @@
       "gen_ai.token.type",
       "server.address"
     ]
-  }
+  },
+  "findings": [
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'agent_framework.function.invocation.duration' does not exist in the registry.",
+      "context": {
+        "attribute_key": "agent_framework.function.invocation.duration"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'agent_framework.function.name' does not exist in the registry.",
+      "context": {
+        "attribute_key": "agent_framework.function.name"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'edge_group.delivered' does not exist in the registry.",
+      "context": {
+        "attribute_key": "edge_group.delivered"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'edge_group.delivery_status' does not exist in the registry.",
+      "context": {
+        "attribute_key": "edge_group.delivery_status"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'edge_group.id' does not exist in the registry.",
+      "context": {
+        "attribute_key": "edge_group.id"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'edge_group.type' does not exist in the registry.",
+      "context": {
+        "attribute_key": "edge_group.type"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'executor.id' does not exist in the registry.",
+      "context": {
+        "attribute_key": "executor.id"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'executor.type' does not exist in the registry.",
+      "context": {
+        "attribute_key": "executor.type"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "type_mismatch",
+      "message": "Attribute 'gen_ai.response.finish_reasons' has type 'string'. Type should be 'string[]'.",
+      "context": {
+        "attribute_key": "gen_ai.response.finish_reasons",
+        "attribute_type": "string",
+        "expected": "string[]"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'gen_ai.usage.cache_creation.input_tokens' does not exist in the registry.",
+      "context": {
+        "attribute_key": "gen_ai.usage.cache_creation.input_tokens"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'message.payload_type' does not exist in the registry.",
+      "context": {
+        "attribute_key": "message.payload_type"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'message.source_id' does not exist in the registry.",
+      "context": {
+        "attribute_key": "message.source_id"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'message.target_id' does not exist in the registry.",
+      "context": {
+        "attribute_key": "message.target_id"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'message.type' does not exist in the registry.",
+      "context": {
+        "attribute_key": "message.type"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow.definition' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow.definition"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow.description' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow.description"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow.id' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow.id"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow.name' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow.name"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow_builder.description' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow_builder.description"
+      }
+    },
+    {
+      "id": "missing_attribute",
+      "message": "Attribute 'workflow_builder.name' does not exist in the registry.",
+      "context": {
+        "attribute_key": "workflow_builder.name"
+      }
+    },
+    {
+      "id": "missing_metric",
+      "message": "Metric does not exist in the registry."
+    },
+    {
+      "id": "unit_mismatch",
+      "message": "Unit should be '{token}', but found 'tokens'.",
+      "context": {
+        "expected": "{token}",
+        "unit": "tokens"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/anthropic/data.json
+++ b/reference/scenarios/anthropic/data.json
@@ -71,5 +71,6 @@
       "server.address",
       "server.port"
     ]
-  }
+  },
+  "findings": []
 }

--- a/reference/scenarios/autogen/data.json
+++ b/reference/scenarios/autogen/data.json
@@ -31,5 +31,23 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/aws-bedrock-agent/data.json
+++ b/reference/scenarios/aws-bedrock-agent/data.json
@@ -25,5 +25,39 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "invoke_agent"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.usage.input_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.input_tokens",
+        "operation": "invoke_agent"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.usage.output_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.output_tokens",
+        "operation": "invoke_agent"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/aws-bedrock-agentcore/data.json
+++ b/reference/scenarios/aws-bedrock-agentcore/data.json
@@ -13,5 +13,6 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/aws-bedrock/data.json
+++ b/reference/scenarios/aws-bedrock/data.json
@@ -37,5 +37,54 @@
       "gen_ai.usage.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"toolSpec\":{\"description\":\"Get the current weather\",\"inputSchema\":{\"json\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"name\":\"get_weather\"}} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"toolSpec\":{\"description\":\"Get the current weather\",\"inputSchema\":{\"json\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"name\":\"get_weather\"}} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat anthropic.claude-3-haiku-20240307-v1:0' (operation 'chat') is missing expected attribute 'gen_ai.response.id'",
+      "context": {
+        "missing_attribute": "gen_ai.response.id",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat anthropic.claude-3-haiku-20240307-v1:0' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat' (operation 'chat') is missing expected attribute 'gen_ai.response.id'",
+      "context": {
+        "missing_attribute": "gen_ai.response.id",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/azure-ai-evaluation/data.json
+++ b/reference/scenarios/azure-ai-evaluation/data.json
@@ -8,5 +8,6 @@
       "gen_ai.evaluation.score.value"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/azure-ai-foundry/data.json
+++ b/reference/scenarios/azure-ai-foundry/data.json
@@ -32,5 +32,31 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent refimpl-test-agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "invoke_agent"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/azure-ai-inference/data.json
+++ b/reference/scenarios/azure-ai-inference/data.json
@@ -38,5 +38,38 @@
       "server.port"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.usage.input_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.input_tokens",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.usage.output_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.output_tokens",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/azure-openai/data.json
+++ b/reference/scenarios/azure-openai/data.json
@@ -25,5 +25,6 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/claude-agent-sdk/data.json
+++ b/reference/scenarios/claude-agent-sdk/data.json
@@ -13,5 +13,24 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat claude' (operation 'chat') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_span_name_format",
+      "message": "chat span name should be 'chat' or 'chat <value of gen_ai.request.model>', got 'chat claude'",
+      "context": {
+        "expected_form": "chat or 'chat <gen_ai.request.model>'",
+        "keyed_attr": "gen_ai.request.model",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/cohere/data.json
+++ b/reference/scenarios/cohere/data.json
@@ -33,5 +33,30 @@
       "gen_ai.usage.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat command-r-plus' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/crewai/data.json
+++ b/reference/scenarios/crewai/data.json
@@ -40,5 +40,23 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"title\":\"Location\",\"type\":\"string\"}},\"required\":[\"location\"],\"title\":\"Get_Weather\",\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"title\":\"Location\",\"type\":\"string\"}},\"required\":[\"location\"],\"title\":\"Get_Weather\",\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/deepeval/data.json
+++ b/reference/scenarios/deepeval/data.json
@@ -7,5 +7,6 @@
       "gen_ai.evaluation.score.value"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/dspy/data.json
+++ b/reference/scenarios/dspy/data.json
@@ -7,5 +7,6 @@
       "gen_ai.evaluation.score.value"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/google-adk/data.json
+++ b/reference/scenarios/google-adk/data.json
@@ -61,5 +61,39 @@
     "gen_ai.invoke_agent.tool_calls": [
       "gen_ai.agent.name"
     ]
-  }
+  },
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"description\":\"Get the current weather.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"STRING\"}},\"required\":[\"location\"],\"type\":\"OBJECT\"}} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"description\":\"Get the current weather.\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"STRING\"}},\"required\":[\"location\"],\"type\":\"OBJECT\"}} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "unit_mismatch",
+      "message": "Unit should be '{inference_call}', but found '1'.",
+      "context": {
+        "expected": "{inference_call}",
+        "unit": "1"
+      }
+    },
+    {
+      "id": "unit_mismatch",
+      "message": "Unit should be '{tool_call}', but found '1'.",
+      "context": {
+        "expected": "{tool_call}",
+        "unit": "1"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/google-genai/data.json
+++ b/reference/scenarios/google-genai/data.json
@@ -81,5 +81,63 @@
       "gen_ai.usage.text.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function_declarations\":[{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}}]} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function_declarations\":[{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}}]} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'gen_ai.response.id'",
+      "context": {
+        "missing_attribute": "gen_ai.response.id",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'create_agent reference-agent' (operation 'create_agent') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "create_agent"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent interactions_agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "invoke_agent"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent interactions_agent' (operation 'invoke_agent') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "invoke_agent"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/groq/data.json
+++ b/reference/scenarios/groq/data.json
@@ -26,5 +26,46 @@
       "gen_ai.usage.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat llama-3.1-8b-instant' (operation 'chat') is missing expected attribute 'gen_ai.usage.input_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.input_tokens",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat llama-3.1-8b-instant' (operation 'chat') is missing expected attribute 'gen_ai.usage.output_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.output_tokens",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat llama-3.1-8b-instant' (operation 'chat') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/haystack/data.json
+++ b/reference/scenarios/haystack/data.json
@@ -9,5 +9,6 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/langchain/data.json
+++ b/reference/scenarios/langchain/data.json
@@ -38,5 +38,23 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent weather-agent' (operation 'invoke_agent') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "invoke_agent"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/litellm/data.json
+++ b/reference/scenarios/litellm/data.json
@@ -34,5 +34,70 @@
       "gen_ai.usage.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.response.id'",
+      "context": {
+        "missing_attribute": "gen_ai.response.id",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.usage.input_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.input_tokens",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.usage.output_tokens'",
+      "context": {
+        "missing_attribute": "gen_ai.usage.output_tokens",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/llamaindex/data.json
+++ b/reference/scenarios/llamaindex/data.json
@@ -22,5 +22,6 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": []
 }

--- a/reference/scenarios/mistralai/data.json
+++ b/reference/scenarios/mistralai/data.json
@@ -50,5 +50,22 @@
       "gen_ai.usage.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "required_attribute_not_present",
+      "message": "Required attribute 'gen_ai.provider.name' is not present.",
+      "context": {
+        "attribute_key": "gen_ai.provider.name"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/openai-agents/data.json
+++ b/reference/scenarios/openai-agents/data.json
@@ -30,5 +30,23 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"location\":{\"title\":\"Location\",\"type\":\"string\"}},\"required\":[\"location\"],\"title\":\"get_weather_args\",\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"location\":{\"title\":\"Location\",\"type\":\"string\"}},\"required\":[\"location\"],\"title\":\"get_weather_args\",\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/openai-assistants/data.json
+++ b/reference/scenarios/openai-assistants/data.json
@@ -42,5 +42,40 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.output.messages' value does not conform to the GenAI schema: \"finish_reason\" is a required property",
+      "context": {
+        "attribute": "gen_ai.output.messages",
+        "errors": "\"finish_reason\" is a required property"
+      }
+    },
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'invoke_agent refimpl-test-assistant' (operation 'invoke_agent') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "invoke_agent"
+      }
+    },
+    {
+      "id": "genai_span_name_format",
+      "message": "execute_tool span name should be 'execute_tool' or 'execute_tool <value of gen_ai.tool.name>', got 'execute_tool'",
+      "context": {
+        "expected_form": "execute_tool or 'execute_tool <gen_ai.tool.name>'",
+        "keyed_attr": "gen_ai.tool.name",
+        "operation": "execute_tool"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/openai/data.json
+++ b/reference/scenarios/openai/data.json
@@ -84,5 +84,31 @@
       "server.port"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-audio-preview' (operation 'chat') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gpt-4o-mini' (operation 'chat') is missing expected attribute 'gen_ai.response.finish_reasons'",
+      "context": {
+        "missing_attribute": "gen_ai.response.finish_reasons",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/pydantic-ai/data.json
+++ b/reference/scenarios/pydantic-ai/data.json
@@ -31,5 +31,15 @@
     ]
   },
   "events": {},
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function\":{\"description\":\"Get the current weather for a location.\",\"name\":\"get_weather\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    }
+  ]
 }

--- a/reference/scenarios/vertexai/data.json
+++ b/reference/scenarios/vertexai/data.json
@@ -49,5 +49,39 @@
       "gen_ai.usage.text.output_tokens"
     ]
   },
-  "metrics": {}
+  "metrics": {},
+  "findings": [
+    {
+      "id": "genai_content_schema",
+      "message": "Attribute 'gen_ai.tool.definitions' value does not conform to the GenAI schema: {\"function_declarations\":[{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}}]} is not valid under any of the schemas listed in the 'anyOf' keyword",
+      "context": {
+        "attribute": "gen_ai.tool.definitions",
+        "errors": "{\"function_declarations\":[{\"description\":\"Get the current weather\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"City name\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}}]} is not valid under any of the schemas listed in the 'anyOf' keyword"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'gen_ai.response.id'",
+      "context": {
+        "missing_attribute": "gen_ai.response.id",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'gen_ai.response.model'",
+      "context": {
+        "missing_attribute": "gen_ai.response.model",
+        "operation": "chat"
+      }
+    },
+    {
+      "id": "genai_expected_attribute_missing",
+      "message": "Span 'chat gemini-2.0-flash' (operation 'chat') is missing expected attribute 'server.address'",
+      "context": {
+        "missing_attribute": "server.address",
+        "operation": "chat"
+      }
+    }
+  ]
 }

--- a/versions.env
+++ b/versions.env
@@ -7,4 +7,4 @@ POLICY_REPO_REF=d84341cf20a1fef1a833ef44d318c41a770e6e64
 
 # renovate: datasource=git-refs depName=open-telemetry/semantic-conventions-conformance versioning=git ref=main
 CONFORMANCE_REPO_URL=https://github.com/open-telemetry/semantic-conventions-conformance.git
-CONFORMANCE_REF=a31794c97dd824ec6d2cb128f910c2ff748b6069
+CONFORMANCE_REF=ded9a0f82b7cee1b9de4d9c2cd1fc449a512787b


### PR DESCRIPTION
## Description

Updates the pinned conformance runner to include https://github.com/open-telemetry/semantic-conventions-conformance/pull/34 to record weaver findings in reference scenario data files.

## Motivation

N/A. Internal reference scenario tooling update to track policy findings.

## Prototype

Updated reference scenario data files using the new runner.

## Checklist

- [x] Motivation section filled in above
- [x] Reference scenarios updated for affected libraries
- [ ] Towncrier fragment added under `changelog.d/` for any change to the conventions that a consumer would care about. Editorial changes (typos, pure rewording, repo tooling) don't need an entry.
